### PR TITLE
Added celery_task_runtime metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,4 @@ celery_task_revoked_total | Sent if the task has been revoked. | Counter
 celery_task_retried_total | Sent if the task failed, but will be retried in the future. | Counter
 celery_worker_up | Indicates if a worker has recently sent a heartbeat. | Gauge
 celery_worker_tasks_active | The number of tasks the worker is currently processing | Gauge
+celery_worker_runtime | Histogram of runtime measurements for each task | Histogram

--- a/src/cli.py
+++ b/src/cli.py
@@ -19,6 +19,7 @@ click.core._verify_python3_env = lambda: None  # pylint: disable=protected-acces
     show_default=True,
     help="The port the exporter will listen on",
 )
-def cli(broker_url, port):  # pylint: disable=unused-argument
+@click.option("--buckets", help="Buckets for runtime histogram, e.g '0.005,0.01,inf'")
+def cli(broker_url, port, buckets):  # pylint: disable=unused-argument
     ctx = click.get_current_context()
-    Exporter().run(ctx.params)
+    Exporter(buckets).run(ctx.params)

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,11 +1,14 @@
 import click
 import pretty_errors  # pylint: disable=unused-import
+from prometheus_client import Histogram
 
 from .exporter import Exporter
 from .help import cmd_help
 
 # https://github.com/pallets/click/issues/448#issuecomment-246029304
 click.core._verify_python3_env = lambda: None  # pylint: disable=protected-access
+
+default_buckets_str = ",".join(map(str, Histogram.DEFAULT_BUCKETS))
 
 
 @click.command(help=cmd_help)
@@ -19,7 +22,13 @@ click.core._verify_python3_env = lambda: None  # pylint: disable=protected-acces
     show_default=True,
     help="The port the exporter will listen on",
 )
-@click.option("--buckets", help="Buckets for runtime histogram, e.g '0.005,0.01,inf'")
+@click.option(
+    "--buckets",
+    default=default_buckets_str,
+    show_default=True,
+    help="Buckets for runtime histogram",
+)
 def cli(broker_url, port, buckets):  # pylint: disable=unused-argument
+    formatted_buckets = list(map(float, buckets.split(",")))
     ctx = click.get_current_context()
-    Exporter(buckets).run(ctx.params)
+    Exporter(formatted_buckets).run(ctx.params)

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -12,7 +12,6 @@ class Exporter:
     state = None
 
     def __init__(self, buckets=None):
-        formatted_buckets = list(map(float, buckets.split(","))) if buckets else None
         self.registry = CollectorRegistry(auto_describe=True)
         self.state_counters = {
             "task-sent": Counter(
@@ -88,7 +87,7 @@ class Exporter:
             "Histogram of task runtime measurements.",
             ["name", "hostname"],
             registry=self.registry,
-            buckets=formatted_buckets or Histogram.DEFAULT_BUCKETS,
+            buckets=buckets or Histogram.DEFAULT_BUCKETS,
         )
 
     def track_task_event(self, event):

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -12,7 +12,7 @@ class Exporter:
     state = None
 
     def __init__(self, buckets=None):
-        formatted_buckets = list(map(float, buckets.split(','))) if buckets else None
+        formatted_buckets = list(map(float, buckets.split(","))) if buckets else None
         self.registry = CollectorRegistry(auto_describe=True)
         self.state_counters = {
             "task-sent": Counter(
@@ -115,8 +115,12 @@ class Exporter:
 
         if event["type"] == "task-succeeded":
             self.celery_task_runtime.labels(**labels).observe(task.runtime)
-            logger.debug("Observed metric='{}' labels='{}': {}s", self.celery_task_runtime._name, labels, task.runtime)
-
+            logger.debug(
+                "Observed metric='{}' labels='{}': {}s",
+                self.celery_task_runtime._name,
+                labels,
+                task.runtime,
+            )
 
     def track_worker_status(self, event, is_online):
         value = 1 if is_online else 0

--- a/src/help.py
+++ b/src/help.py
@@ -46,7 +46,11 @@ for metric in temp_exporter.state_counters.values():
 {metric._documentation:30s}
 """
 
-for metric in [temp_exporter.celery_worker_up, temp_exporter.worker_tasks_active]:
+for metric in [
+    temp_exporter.celery_worker_up,
+    temp_exporter.worker_tasks_active,
+    temp_exporter.celery_task_runtime,
+]:
     cmd_help += f"""
 \b
 {metric._name}

--- a/src/test_cli.py
+++ b/src/test_cli.py
@@ -58,3 +58,7 @@ def test_integration(celery_app, celery_worker):
         f'celery_task_failed_total{{exception="HTTPError",hostname="{celery_worker.hostname}",name="src.test_cli.fail"}} 1.0'
         in res.text
     )
+    assert (
+        f'celery_task_runtime_count{{hostname="{celery_worker.hostname}",name="src.test_cli.succeed"}} 2.0'
+        in res.text
+    )


### PR DESCRIPTION
Hi Dani,

Thanks for your great library! I’d like to contribute one simple metric that I felt was missing. It’s simple Histogram which tracks runtime that celery sends with task-succeeded event. I also added one optional CLI argument, ‘buckets’, for histogram buckets initialization. I hope you find it useful. Looking forward to your comments if something’s off in the code.