### PR TITLE
Use docker container for stable pyinstaller builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,4 @@ dmypy.json
 # End of https://www.toptal.com/developers/gitignore/api/python
 
 .virtualenv
+celery-exporter

--- a/Dockerfile.pyinstaller
+++ b/Dockerfile.pyinstaller
@@ -1,0 +1,19 @@
+FROM danihodovic/pyinstaller-builder:latest
+
+ARG PYTHON_VERSION=3.9.2
+
+RUN pyenv install $PYTHON_VERSION && pyenv global $PYTHON_VERSION
+
+RUN pip install poetry
+
+WORKDIR /app/
+
+COPY ./pyproject.toml ./poetry.lock /app/
+
+RUN poetry install
+
+COPY . /app/
+
+RUN eval "$(pyenv init -)" && \
+        pyinstaller cli.py -y --onefile --name celery-exporter && \
+        staticx ./dist/celery-exporter ./dist/celery-exporter

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,12 +9,12 @@ tasks:
       - docker build . -t danihodovic/celery-exporter
 
   build-binary:
-    desc: Creates a cross platform binary
+    desc: Creates a binary
     cmds:
-      - pyinstaller cli.py -y
-        --onefile
-        --name celery-exporter
-      - staticx ./dist/celery-exporter ./dist/celery-exporter
+      - docker build . -t celery-exporter-builder -f Dockerfile.pyinstaller --build-arg PYTHON_VERSION=$(cat .python-version)
+      - >
+        container=$(docker run --rm -d celery-exporter-builder sleep 5) &&
+        docker cp $container:/app/dist/celery-exporter celery-exporter
 
   release:
     desc: Creates a Github release
@@ -40,4 +40,4 @@ tasks:
         --repo celery-exporter
         --tag latest
         --name celery-exporter
-        --file ./dist/celery-exporter
+        --file ./celery-exporter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ skip = '.virtualenv,.venv'
 
 [tool.poetry]
 name = "celery-exporter"
-version = "0.0.1"
+version = "0.0.2"
 description = ""
 authors = ["Dani Hodovic <dani.hodovic@gmail.com>"]
 


### PR DESCRIPTION
Uses a base image with Ubuntu:16.04 which should be compatible with
distros that have an older version of glibc.
