### PR TITLE
Added support for the --retry-interval command line option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,13 +99,25 @@ one or more --broker-transport-option parameters as follows:
 
 ```sh
 docker run -p 9808:9808 danihodovic/celery-exporter --broker-url=redis://redis.service.consul/1 \
-  --broker-transport-option globalkeyprefix=danihodovic \
+  --broker-transport-option global_keyprefix=danihodovic \
   --broker-transport-option visibility_timeout=7200
 ```
 
 The list of available broker transport options can be found here:
 https://docs.celeryq.dev/projects/kombu/en/stable/reference/kombu.transport.redis.html
 
+
+###### Specifying an optional retry interval
+
+By default, celery-exporter will raise an exception and exit if there
+are any errors communicating with the broker. If preferred, one can
+have the celery-exporter retry connecting to the broker after a certain
+period of time in seconds via the `--retry-interval` parameter as follows:
+
+```sh
+docker run -p 9808:9808 danihodovic/celery-exporter --broker-url=redis://redis.service.consul/1 \
+  --retry-interval=5
+```
 
 ##### Grafana Dashboards & Prometheus Alerts
 

--- a/conftest.py
+++ b/conftest.py
@@ -45,6 +45,7 @@ def exporter(find_free_port, celery_config):
         "port": find_free_port(),
         "broker_url": celery_config["broker_url"],
         "broker_transport_option": ["visibility_timeout=7200"],
+        "retry_interval": 5,
         "log_level": "DEBUG",
     }
     exporter = Exporter()

--- a/src/cli.py
+++ b/src/cli.py
@@ -26,6 +26,12 @@ default_buckets_str = ",".join(map(str, Histogram.DEFAULT_BUCKETS))
     help="Celery broker transport option, e.g visibility_timeout=18000",
 )
 @click.option(
+    "--retry-interval",
+    required=False,
+    default=0,
+    help="Broker exception retry interval in seconds, default is 0 for no retry",
+)
+@click.option(
     "--port",
     type=int,
     default=9808,
@@ -44,7 +50,7 @@ default_buckets_str = ",".join(map(str, Histogram.DEFAULT_BUCKETS))
     show_default=True,
 )
 def cli(
-    broker_url, broker_transport_option, port, buckets, log_level
+    broker_url, broker_transport_option, retry_interval, port, buckets, log_level
 ):  # pylint: disable=unused-argument
     formatted_buckets = list(map(float, buckets.split(",")))
     ctx = click.get_current_context()

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -173,6 +173,8 @@ class Exporter:
 
         self.state = self.app.events.State()
         self.retry_interval = click_params["retry_interval"]
+        if self.retry_interval:
+            logger.debug("Using retry_interval of {} seconds", self.retry_interval)
 
         handlers = {
             "worker-heartbeat": self.track_worker_heartbeat,

--- a/src/test_cli.py
+++ b/src/test_cli.py
@@ -19,6 +19,7 @@ def test_integration(celery_app, celery_worker):
                 "--port=23000",
                 "--broker-transport-option",
                 "visibility_timeout=7200",
+                "--retry-interval=5",
             ],
         )
 


### PR DESCRIPTION
### Added support for the --retry-interval command line option.

It is intended as a broker exception retry interval and is specified as number of seconds.

By default, if there is an exception while communicating with the broker, celery-exporter exits with a stack trace.

It is not uncommon to temporarily lose connectivity to redis for a very short amount of time. With the default behavior, the
exporter will need a restart thus losing all accumulated metrics.

With the new --retry-interval options specified, one can specify and optional retry interval (i.e. 5 seconds) and
celery-exporter will restart the celery EventReceiver for that broker.

The default is 0, (i.e. do not retry) in order to keep compatibility (and expected behavior) with the current
celery-exporter.