### PR TITLE
Adding support for Celery broker_transport_options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,22 @@ chmod+x ./celery-exporter
 ./celery-exporter --broker-url=redis://redis.service.consul/1
 ```
 
+###### Specifying optional broker transport options
+
+While the default options may be fine for most cases,
+there may be a need to specify optional broker transport options. This can be done by specifying
+one or more --broker-transport-option parameters as follows:
+
+```sh
+docker run -p 9808:9808 danihodovic/celery-exporter --broker-url=redis://redis.service.consul/1 \
+  --broker-transport-option globalkeyprefix=danihodovic \
+  --broker-transport-option visibility_timeout=7200
+```
+
+The list of available broker transport options can be found here:
+https://docs.celeryq.dev/projects/kombu/en/stable/reference/kombu.transport.redis.html
+
+
 ##### Grafana Dashboards & Prometheus Alerts
 
 Head over to the [Celery-mixin in this subdirectory](https://github.com/danihodovic/celery-exporter/tree/master/celery-mixin) to generate rules and dashboards suited to your Prometheus setup.

--- a/conftest.py
+++ b/conftest.py
@@ -44,6 +44,7 @@ def exporter(find_free_port, celery_config):
     cfg = {
         "port": find_free_port(),
         "broker_url": celery_config["broker_url"],
+        "broker_transport_option": ["visibility_timeout=7200"],
         "log_level": "DEBUG",
     }
     exporter = Exporter()

--- a/src/cli.py
+++ b/src/cli.py
@@ -19,6 +19,13 @@ default_buckets_str = ",".join(map(str, Histogram.DEFAULT_BUCKETS))
     "--broker-url", required=True, help="The url to the broker, e.g redis://1.2.3.4"
 )
 @click.option(
+    "--broker-transport-option",
+    required=False,
+    default=[None],
+    multiple=True,
+    help="Celery broker transport option, e.g visibility_timeout=18000",
+)
+@click.option(
     "--port",
     type=int,
     default=9808,
@@ -36,7 +43,9 @@ default_buckets_str = ",".join(map(str, Histogram.DEFAULT_BUCKETS))
     default="INFO",
     show_default=True,
 )
-def cli(broker_url, port, buckets, log_level):  # pylint: disable=unused-argument
+def cli(
+    broker_url, broker_transport_option, port, buckets, log_level
+):  # pylint: disable=unused-argument
     formatted_buckets = list(map(float, buckets.split(",")))
     ctx = click.get_current_context()
     Exporter(formatted_buckets).run(ctx.params)

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -154,6 +154,19 @@ class Exporter:
         logger.remove()
         logger.add(sys.stdout, level=click_params["log_level"])
         self.app = Celery(broker=click_params["broker_url"])
+        transport_options = {}
+        for transport_option in click_params["broker_transport_option"]:
+            if transport_option is not None:
+                option, value = transport_option.split("=", 1)
+                if option is not None:
+                    if value.isnumeric():
+                        transport_options[option] = int(value)
+                    else:
+                        transport_options[option] = value
+
+        if transport_options is not None:
+            self.app.conf["broker_transport_options"] = transport_options
+
         self.state = self.app.events.State()
 
         handlers = {

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -159,6 +159,9 @@ class Exporter:
             if transport_option is not None:
                 option, value = transport_option.split("=", 1)
                 if option is not None:
+                    logger.debug(
+                        "Setting celery broker_transport_option {}={}", option, value
+                    )
                     if value.isnumeric():
                         transport_options[option] = int(value)
                     else:

--- a/src/test_cli.py
+++ b/src/test_cli.py
@@ -12,7 +12,15 @@ from .cli import cli
 @pytest.mark.celery()
 def test_integration(celery_app, celery_worker):
     def run():
-        CliRunner().invoke(cli, ["--broker-url=memory://localhost", "--port=23000"])
+        CliRunner().invoke(
+            cli,
+            [
+                "--broker-url=memory://localhost",
+                "--port=23000",
+                "--broker-transport-option",
+                "visibility_timeout=7200",
+            ],
+        )
 
     threading.Thread(target=run, daemon=True).start()
 


### PR DESCRIPTION
### Adding support for Celery broker_transport_options.

When communicating with redis that has been configured to receive prefixed keys from workers via either ye-old CELERY_BROKER_TRANSPORT_OPTIONS or the newer broker_transport_options with the "global_keyprefix" option,
celery-exporter does not properly subscribe to those keys, events will not be seen and thus no metrics updated.

This PR adds the ability to specify one or more `--broker_transport_option` on the cli that will be honored by celery-exporter and the appropriate celery config updated.

   i.e.  
```
python /app/cli.py --broker redis://my_redis:6379 \
                            --broker_transport_option global_keyprefix=aab \
                            --broker_transport_option visibility_timeout=10800
                            ...
```