### PR TITLE
support for environment variables

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,4 +1,4 @@
 from src.cli import cli
 
 if __name__ == "__main__":
-    cli()  # pylint: disable=no-value-for-parameter
+    cli(auto_envvar_prefix="CELERY_EXPORTER_")  # pylint: disable=no-value-for-parameter

--- a/src/cli.py
+++ b/src/cli.py
@@ -16,7 +16,10 @@ default_buckets_str = ",".join(map(str, Histogram.DEFAULT_BUCKETS))
 
 @click.command(help=cmd_help)
 @click.option(
-    "--broker-url", required=True, help="The url to the broker, e.g redis://1.2.3.4"
+    "--broker-url",
+    required=True,
+    help="The url to the broker, e.g redis://1.2.3.4",
+    envvar="BROKER_URI",
 )
 @click.option(
     "--broker-transport-option",
@@ -24,12 +27,14 @@ default_buckets_str = ",".join(map(str, Histogram.DEFAULT_BUCKETS))
     default=[None],
     multiple=True,
     help="Celery broker transport option, e.g visibility_timeout=18000",
+    envvar="BROKER_TRANSPORT_OPTIONS",
 )
 @click.option(
     "--retry-interval",
     required=False,
     default=0,
     help="Broker exception retry interval in seconds, default is 0 for no retry",
+    envvar="RETRY_INTERVAL",
 )
 @click.option(
     "--port",
@@ -37,18 +42,16 @@ default_buckets_str = ",".join(map(str, Histogram.DEFAULT_BUCKETS))
     default=9808,
     show_default=True,
     help="The port the exporter will listen on",
+    envvar="PORT",
 )
 @click.option(
     "--buckets",
     default=default_buckets_str,
     show_default=True,
     help="Buckets for runtime histogram",
+    envvar="BUCKETS",
 )
-@click.option(
-    "--log-level",
-    default="INFO",
-    show_default=True,
-)
+@click.option("--log-level", default="INFO", show_default=True, envvar="LOG_LEVEL")
 def cli(  # pylint: disable=too-many-arguments
     broker_url, broker_transport_option, retry_interval, port, buckets, log_level
 ):  # pylint: disable=unused-argument

--- a/src/cli.py
+++ b/src/cli.py
@@ -19,7 +19,6 @@ default_buckets_str = ",".join(map(str, Histogram.DEFAULT_BUCKETS))
     "--broker-url",
     required=True,
     help="The url to the broker, e.g redis://1.2.3.4",
-    envvar="BROKER_URI",
 )
 @click.option(
     "--broker-transport-option",
@@ -27,14 +26,12 @@ default_buckets_str = ",".join(map(str, Histogram.DEFAULT_BUCKETS))
     default=[None],
     multiple=True,
     help="Celery broker transport option, e.g visibility_timeout=18000",
-    envvar="BROKER_TRANSPORT_OPTIONS",
 )
 @click.option(
     "--retry-interval",
     required=False,
     default=0,
     help="Broker exception retry interval in seconds, default is 0 for no retry",
-    envvar="RETRY_INTERVAL",
 )
 @click.option(
     "--port",
@@ -42,16 +39,14 @@ default_buckets_str = ",".join(map(str, Histogram.DEFAULT_BUCKETS))
     default=9808,
     show_default=True,
     help="The port the exporter will listen on",
-    envvar="PORT",
 )
 @click.option(
     "--buckets",
     default=default_buckets_str,
     show_default=True,
     help="Buckets for runtime histogram",
-    envvar="BUCKETS",
 )
-@click.option("--log-level", default="INFO", show_default=True, envvar="LOG_LEVEL")
+@click.option("--log-level", default="INFO", show_default=True)
 def cli(  # pylint: disable=too-many-arguments
     broker_url, broker_transport_option, retry_interval, port, buckets, log_level
 ):  # pylint: disable=unused-argument


### PR DESCRIPTION
Adds support for using environment variables to configure the exporter. Useful when running outside of Kubernetes, where secrets are handled .. chaotically. Example for AWS Fargate:

```
        secrets = [
          {
            name      = "RABBIT_USER"
            valueFrom = "arn:aws:ssm:user-parameter"
          },
          {
            name      = "RABBIT_PASSWORD"
            valueFrom = "arn:aws:ssm:password"
          }
        ]
        environment = [
          {
            name = "BROKER_URL"
            value = "amqps://${RABBIT_USER}:${RABBIT_PASSWORD}@broker-id.mq.amazonaws.com:5671/vhost"
          },
          {
            name = "RETRY_INTERVAL"
            value = "15"
          }
        ]
```