### PR TITLE
Remove a  prefix `gen4312` from a hostname

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -52,3 +52,8 @@ def exporter(find_free_port, celery_config):
     exporter = Exporter()
     setattr(exporter, "cfg", cfg)
     yield exporter
+
+
+@pytest.fixture()
+def hostname():
+    return socket.gethostname()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --pdbcls=pudb.debugger:Debugger
+addopts = --pdbcls=pudb.debugger:Debugger --doctest-modules
 python_files = tests.py test_*.py
 norecursedirs = .git .venv .virtualenv
 log_cli = true


### PR DESCRIPTION
The exporter are using original `hostname` value from celery's events data. 
Celery uses [anon_nodename](https://docs.celeryq.dev/en/stable/internals/reference/celery.utils.nodenames.html?highlight=anon_nodename#celery.utils.nodenames.anon_nodename) to get the value and the value has format "prefix@hostname".

The prefix part is different depending on type of a process:
1. For workers the prefix is a worker's name, e.g., `worker1@allburov`
2. For senders the prefix has a format `genPID@hostname` where PID is Process ID, e.g., `gen1231234@allburov`

The part with PID has high cardinality and it leads to too much metrics in Prometheus (as described in  https://github.com/danihodovic/celery-exporter/issues/116)

[Prometheus suggests](https://prometheus.io/docs/practices/naming/):
>CAUTION: Remember that every unique combination of key-value label pairs represents a new time series, which can dramatically increase the amount of data stored. Do not use labels to store dimensions with high cardinality (many different label values), such as user IDs, email addresses, or other unbounded sets of values.

----

This PR removes prefix with PID for task-sent events - it's the only event that usually has PID in the hostname. 

I decided to keep using the prefix for workers because one can run few workers on the same host by using `--hostname` flag and it'll help them to understand what is going on there.
```
$ celery -A proj worker --loglevel=INFO --concurrency=10 -n worker1@%h
$ celery -A proj worker --loglevel=INFO --concurrency=10 -n worker2@%h
$ celery -A proj worker --loglevel=INFO --concurrency=10 -n worker3@%h
```

I thought about doing it a bit different way - we could always set `hostname` label to the pure-hostname value (without a prefix) and add `worker` label for these types of events that we can say "it belongs to THIS worker", so we'll have three dimensions labels for most of metrics - `name, hostname, [worker]`

What are you thoughts, does it make sense? 
Give me a feedback and we can work on that in the right direction! 