### PR TITLE
Add tests for celery_task_sent_total

### DIFF
--- a/src/test_cli.py
+++ b/src/test_cli.py
@@ -24,6 +24,7 @@ def test_integration(celery_app, celery_worker):
         )
 
     threading.Thread(target=run, daemon=True).start()
+    time.sleep(2)
 
     @celery_app.task
     def succeed():
@@ -43,6 +44,14 @@ def test_integration(celery_app, celery_worker):
     assert res.status_code == 200
 
     # pylint: disable=line-too-long
+    assert (
+        f'celery_task_sent_total{{hostname="{celery_worker.hostname}",name="src.test_cli.succeed"}} 2.0'
+        in res.text
+    )
+    assert (
+        f'celery_task_sent_total{{hostname="{celery_worker.hostname}",name="src.test_cli.fail"}} 1.0'
+        in res.text
+    )
     assert (
         f'celery_task_received_total{{hostname="{celery_worker.hostname}",name="src.test_cli.succeed"}} 2.0'
         in res.text


### PR DESCRIPTION
Add tests for celery_task_sent_total

If you're working with async test - just add more `sleep`, usually it helps :D 
I think there's a problem with daemon - it `threading.Thread.start` waits until the thread is ready, not when the app is healthy and connected to a broker - so we missed `task-sent` events.

Fixes https://github.com/danihodovic/celery-exporter/issues/121