### PR TITLE
fix: Change env var prefix and change service monitor port

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,18 @@ chmod+x ./celery-exporter
 ./celery-exporter --broker-url=redis://redis.service.consul/1
 ```
 
+###### Kubernetes
+
+There's a Helm in the directory `charts/celery-exporter` for deploying the Celery-exporter to Kubernetes using Helm.
+
+###### Environment variables
+
+All arguments can be specified using environment variables with a `CE_` prefix:
+
+```sh
+docker run -p 9808:9808 -e CE_BROKER_URL=redis://redis danihodovic/celery-exporter
+```
+
 ###### Specifying optional broker transport options
 
 While the default options may be fine for most cases,

--- a/charts/celery-exporter/Chart.yaml
+++ b/charts/celery-exporter/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: danihodovic
   - name: adinhodovic
 
-version: 0.2.0
-appVersion: 0.3.0
+version: 0.3.0
+appVersion: 0.4.0

--- a/charts/celery-exporter/templates/servicemonitor.yaml
+++ b/charts/celery-exporter/templates/servicemonitor.yaml
@@ -13,7 +13,7 @@ metadata:
   {{- end }}
 spec:
   endpoints:
-    - port: metrics
+    - port: http
       interval: {{ .Values.serviceMonitor.scrapeInterval }}
     {{- if .Values.serviceMonitor.honorLabels }}
       honorLabels: true

--- a/charts/celery-exporter/values.yaml
+++ b/charts/celery-exporter/values.yaml
@@ -24,9 +24,9 @@ serviceAccount:
   name: ""
 
 env: []
-  # - name: CELERY_EXPORTER_BROKER_URL
+  # - name: CE_BROKER_URL
   #   value: <MY_BROKER_URL>
-  # - name: CELERY_EXPORTER_BROKER_URL
+  # - name: CE_BROKER_URL
   #   valueFrom:
   #     secretKeyRef:
   #       name: MY_SECRET

--- a/cli.py
+++ b/cli.py
@@ -2,4 +2,4 @@ from src.cli import cli
 
 if __name__ == "__main__":
     # pylint: disable=no-value-for-parameter,unexpected-keyword-arg
-    cli(auto_envvar_prefix="CELERY_EXPORTER")
+    cli(auto_envvar_prefix="CE")


### PR DESCRIPTION
`CELERY_EXPORTER` as a prefix collides with default Kubernetes environment variables as `CELERY_EXPORTER_PORT` and others used for service discovery. 

https://kubernetes.io/docs/concepts/services-networking/service/#environment-variables