### PR TITLE
Ignore big directories in docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,10 @@
 .virtualenv
 .venv
+.mypy_cache
+.pytest_cache
+.git
+build
+dist
+images
+__pycache__
+vendor


### PR DESCRIPTION
[The last image](https://hub.docker.com/layers/celery-exporter/danihodovic/celery-exporter/0.5.2/images/sha256-1a042ba614f84c7ff8e04b3e6289abb0681bc5f1860e07dc0c444a323464c5ab?context=explore)'s step `COPY . /app/ # buildkit` has size 87.1 MB

I found few unnecessary folders in the `/app/` that we could ignore to reduce an image size 

```
root@4d306fc2ebb2:/app# du -h | grep M
36M     ./build/celery-exporter
36M     ./build
5.1M    ./.git/objects
5.7M    ./.git
1.6M    ./.mypy_cache/3.9/cryptography/hazmat
2.2M    ./.mypy_cache/3.9/cryptography
1.3M    ./.mypy_cache/3.9/jinja2
2.3M    ./.mypy_cache/3.9/_pytest
2.0M    ./.mypy_cache/3.9/werkzeug
24M     ./.mypy_cache/3.9
24M     ./.mypy_cache
26M     ./dist
```
