### PR TITLE
don't log exceptions for ChannelErrors from redis

### DIFF
--- a/src/exporter.py
+++ b/src/exporter.py
@@ -6,6 +6,7 @@ import time
 from celery import Celery
 from celery.events.state import State  # type: ignore
 from celery.utils import nodesplit  # type: ignore
+from kombu.exceptions import ChannelError  # type: ignore
 from loguru import logger
 from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram
 
@@ -123,14 +124,13 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
                         queue=queue, passive=True
                     )
                     length, consumer_count = ret.message_count, ret.consumer_count
-                except Exception as ex:  # pylint: disable=broad-except
-                    if not (
-                        type(ex).__name__ == "ChannelError"
-                        and connection.transport_cls == "redis"
-                    ):
-                        logger.exception(f"Queue {queue} declare failed: {str(ex)}")
-                    length = 0
-                    consumer_count = 0
+                except ChannelError as ex:
+                    if "NOT_FOUND" in ex.message:
+                        logger.debug(f"Queue '{queue}' not found")
+                        length = 0
+                        consumer_count = 0
+                    else:
+                        raise ex
                 self.celery_queue_length.labels(queue_name=queue).set(length)
                 self.celery_active_consumer_count.labels(queue_name=queue).set(
                     consumer_count

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -124,7 +124,11 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
                     )
                     length, consumer_count = ret.message_count, ret.consumer_count
                 except Exception as ex:  # pylint: disable=broad-except
-                    logger.exception(f"Queue {queue} declare failed: {str(ex)}")
+                    if not (
+                        type(ex).__name__ == "ChannelError"
+                        and connection.transport_cls == "redis"
+                    ):
+                        logger.exception(f"Queue {queue} declare failed: {str(ex)}")
                     length = 0
                     consumer_count = 0
                 self.celery_queue_length.labels(queue_name=queue).set(length)


### PR DESCRIPTION
fixes #143 
I'm not sure if it's a perfect long-term solution, but right now kombu throws ChannelError on queue_declare only if _has_queue is false. So, we can safely ignore ChannelErrors from redis and won't miss any other exception https://github.com/celery/kombu/blob/7516daf7a774dd9671d16c475c6ac266de977a0a/kombu/transport/virtual/base.py#L521