### PR TITLE
feat: Add custom accept content configuration

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -35,6 +35,12 @@ default_buckets_str = ",".join(map(str, Histogram.DEFAULT_BUCKETS))
     help="Celery broker ssl option, e.g certfile=/var/ssl/amqp-server-cert.pem",
 )
 @click.option(
+    "--accept-content",
+    required=False,
+    default=None,
+    help="Celery accept content options, e.g 'json,pickle'",
+)
+@click.option(
     "--retry-interval",
     required=False,
     default=0,
@@ -57,6 +63,7 @@ default_buckets_str = ",".join(map(str, Histogram.DEFAULT_BUCKETS))
 def cli(  # pylint: disable=too-many-arguments
     broker_url,
     broker_transport_option,
+    accept_content,
     retry_interval,
     port,
     buckets,

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -199,6 +199,10 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
         logger.remove()
         logger.add(sys.stdout, level=click_params["log_level"])
         self.app = Celery(broker=click_params["broker_url"])
+        if click_params["accept_content"] is not None:
+            accept_content_list = click_params["accept_content"].split(",")
+            logger.info("Setting celery accept_content {}", accept_content_list)
+            self.app.config_from_object(dict(accept_content=accept_content_list))
         transport_options = {}
         for transport_option in click_params["broker_transport_option"]:
             if transport_option is not None:


### PR DESCRIPTION
Reference: https://github.com/danihodovic/celery-exporter/issues/153

Problem: celery-exporter expects default Celery configuration.

Proposal: New custom-config parameter allowing configuration load from a module.