### PR TITLE
Using the new poetry dev group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ Flask = "^2.0.3"
 waitress = "^2.0.0"
 pylint = "^2.7.1"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "^7.0.1"
 black = "^22.1.0"
 isort = "^5.10.1"
@@ -42,8 +42,6 @@ types-requests = "^2.27.11"
 types-waitress = "^2.0.6"
 celery-types = "^0.11.0"
 pre-commit = "^2.19.0"
-
-[tool.poetry.group.dev.dependencies]
 pytest-celery = "^0.0.0"
 
 [build-system]


### PR DESCRIPTION
The pyproject.toml file had both old-style and new-style dev dependency grouping. Updated to just use the new poetry style.

Should check that this does not impact CI and builds.

If you don't wish to review the `poetry.lock` file. I'd be happy to re-submit with just the `pyproject.toml` file changes. Then you could perform `poetry lock --no-update` on your own.