### PR TITLE
fix: Unify queue name label

### DIFF
--- a/charts/celery-exporter/Chart.yaml
+++ b/charts/celery-exporter/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   - name: danihodovic
   - name: adinhodovic
 
-version: 0.6.1
-appVersion: 0.7.1
+version: 0.6.2
+appVersion: 0.7.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ skip = '.virtualenv,.venv,.poetry,.poetry-cache'
 
 [tool.poetry]
 name = "celery-exporter"
-version = "0.7.1"
+version = "0.7.2"
 description = ""
 authors = ["Dani Hodovic <dani.hodovic@gmail.com>"]
 

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -24,50 +24,50 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
             "task-sent": Counter(
                 "celery_task_sent",
                 "Sent when a task message is published.",
-                ["name", "hostname", "queue"],
+                ["name", "hostname", "queue_name"],
                 registry=self.registry,
             ),
             "task-received": Counter(
                 "celery_task_received",
                 "Sent when the worker receives a task.",
-                ["name", "hostname", "queue"],
+                ["name", "hostname", "queue_name"],
                 registry=self.registry,
             ),
             "task-started": Counter(
                 "celery_task_started",
                 "Sent just before the worker executes the task.",
-                ["name", "hostname", "queue"],
+                ["name", "hostname", "queue_name"],
                 registry=self.registry,
             ),
             "task-succeeded": Counter(
                 "celery_task_succeeded",
                 "Sent if the task executed successfully.",
-                ["name", "hostname", "queue"],
+                ["name", "hostname", "queue_name"],
                 registry=self.registry,
             ),
             "task-failed": Counter(
                 "celery_task_failed",
                 "Sent if the execution of the task failed.",
-                ["name", "hostname", "exception", "queue"],
+                ["name", "hostname", "exception", "queue_name"],
                 registry=self.registry,
             ),
             "task-rejected": Counter(
                 "celery_task_rejected",
                 # pylint: disable=line-too-long
                 "The task was rejected by the worker, possibly to be re-queued or moved to a dead letter queue.",
-                ["name", "hostname", "queue"],
+                ["name", "hostname", "queue_name"],
                 registry=self.registry,
             ),
             "task-revoked": Counter(
                 "celery_task_revoked",
                 "Sent if the task has been revoked.",
-                ["name", "hostname", "queue"],
+                ["name", "hostname", "queue_name"],
                 registry=self.registry,
             ),
             "task-retried": Counter(
                 "celery_task_retried",
                 "Sent if the task failed, but will be retried in the future.",
-                ["name", "hostname", "queue"],
+                ["name", "hostname", "queue_name"],
                 registry=self.registry,
             ),
         }
@@ -86,7 +86,7 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
         self.celery_task_runtime = Histogram(
             "celery_task_runtime",
             "Histogram of task runtime measurements.",
-            ["name", "hostname", "queue"],
+            ["name", "hostname", "queue_name"],
             registry=self.registry,
             buckets=buckets or Histogram.DEFAULT_BUCKETS,
         )
@@ -148,7 +148,7 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
         labels = {
             "name": task.name,
             "hostname": get_hostname(task.hostname),
-            "queue": getattr(task, "queue", "celery"),
+            "queue_name": getattr(task, "queue", "celery"),
         }
 
         for counter_name, counter in self.state_counters.items():

--- a/src/test_cli.py
+++ b/src/test_cli.py
@@ -49,39 +49,39 @@ def test_integration(broker, celery_app, threaded_exporter, hostname):
     assert res.status_code == 200
     # pylint: disable=line-too-long
     assert (
-        f'celery_task_sent_total{{hostname="{hostname}",name="src.test_cli.succeed",queue="celery"}} 2.0'
+        f'celery_task_sent_total{{hostname="{hostname}",name="src.test_cli.succeed",queue_name="celery"}} 2.0'
         in res.text
     )
     assert (
-        f'celery_task_sent_total{{hostname="{hostname}",name="src.test_cli.fail",queue="celery"}} 1.0'
+        f'celery_task_sent_total{{hostname="{hostname}",name="src.test_cli.fail",queue_name="celery"}} 1.0'
         in res.text
     )
     assert (
-        f'celery_task_received_total{{hostname="{hostname}",name="src.test_cli.succeed",queue="celery"}} 2.0'
+        f'celery_task_received_total{{hostname="{hostname}",name="src.test_cli.succeed",queue_name="celery"}} 2.0'
         in res.text
     )
     assert (
-        f'celery_task_received_total{{hostname="{hostname}",name="src.test_cli.fail",queue="celery"}} 1.0'
+        f'celery_task_received_total{{hostname="{hostname}",name="src.test_cli.fail",queue_name="celery"}} 1.0'
         in res.text
     )
     assert (
-        f'celery_task_started_total{{hostname="{hostname}",name="src.test_cli.succeed",queue="celery"}} 2.0'
+        f'celery_task_started_total{{hostname="{hostname}",name="src.test_cli.succeed",queue_name="celery"}} 2.0'
         in res.text
     )
     assert (
-        f'celery_task_started_total{{hostname="{hostname}",name="src.test_cli.fail",queue="celery"}} 1.0'
+        f'celery_task_started_total{{hostname="{hostname}",name="src.test_cli.fail",queue_name="celery"}} 1.0'
         in res.text
     )
     assert (
-        f'celery_task_succeeded_total{{hostname="{hostname}",name="src.test_cli.succeed",queue="celery"}} 2.0'
+        f'celery_task_succeeded_total{{hostname="{hostname}",name="src.test_cli.succeed",queue_name="celery"}} 2.0'
         in res.text
     )
     assert (
-        f'celery_task_failed_total{{exception="HTTPError",hostname="{hostname}",name="src.test_cli.fail",queue="celery"}} 1.0'
+        f'celery_task_failed_total{{exception="HTTPError",hostname="{hostname}",name="src.test_cli.fail",queue_name="celery"}} 1.0'
         in res.text
     )
     assert (
-        f'celery_task_runtime_count{{hostname="{hostname}",name="src.test_cli.succeed",queue="celery"}} 2.0'
+        f'celery_task_runtime_count{{hostname="{hostname}",name="src.test_cli.succeed",queue_name="celery"}} 2.0'
         in res.text
     )
     assert 'celery_queue_length{queue_name="celery"} 0.0' in res.text


### PR DESCRIPTION
For celery_queue_length the queue name label is `queue_name`, unify it across all metrics. Also, bump to 0.7.2, just publish a docker image
