### PR TITLE
support celery_queue_size metric for sentinels

### DIFF
--- a/src/exporter.py
+++ b/src/exporter.py
@@ -106,7 +106,7 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
     def track_queue_metrics(self):
         with self.app.connection() as connection:  # type: ignore
             transport = connection.info()["transport"]
-            acceptable_transports = ["redis", "rediss", "amqp", "memory"]
+            acceptable_transports = ["redis", "rediss", "amqp", "memory", "sentinel"]
             if transport not in acceptable_transports:
                 logger.debug(
                     f"Queue length tracking is only implemented for {acceptable_transports}"
@@ -125,7 +125,7 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
                 queue_name=q
             ).set(l)
             for queue in self.queue_cache:
-                if transport in ["redis", "rediss"]:
+                if transport in ["redis", "rediss", "sentinel"]:
                     queue_length = redis_queue_length(connection, queue)
                     track_length(queue, queue_length)
                 elif transport in ["amqp", "memory"]:


### PR DESCRIPTION
Implements #220.

This turned out to be much easier than I expected. Celery seems to just handle all the details of the Sentinel connection for us automatically.

Tested with a basic docker-compose stack running sentinel, where I killed the workers and then queued tasks. All the other metrics seemed fine, but the queue size correctly tracked the number of tasks I added as expected:
```
❯ curl localhost:9808/metrics -s | rg celery_queue
# HELP celery_queue_length The number of message in broker queue.
# TYPE celery_queue_length gauge
celery_queue_length{queue_name="default"} 1.0
```

Let me know if there's some other testing or something I should do here, or if there's something I'm missing given how surprisingly easy this was.