### PR TITLE
Add timeout to workers to correct for force killed workers

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -93,8 +93,9 @@ def exporter_instance(find_free_port, celery_config, log_level):
         "retry_interval": 5,
         "log_level": log_level,
         "accept_content": None,
+        "worker_timeout": 1,
     }
-    exporter = Exporter()
+    exporter = Exporter(worker_timeout_seconds=cfg["worker_timeout"])
     setattr(exporter, "cfg", cfg)
     yield exporter
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -66,6 +66,13 @@ default_buckets_str = ",".join(map(str, Histogram.DEFAULT_BUCKETS))
     help="Buckets for runtime histogram",
 )
 @click.option("--log-level", default="INFO", show_default=True)
+@click.option(
+    "--worker-timeout",
+    default=5*60,
+    show_default=True,
+    help="If no heartbeat has been recieved for a worker in this many seconds, "
+         "that a worker will be considered dead.",
+)
 def cli(  # pylint: disable=too-many-arguments
     broker_url,
     broker_transport_option,
@@ -76,7 +83,8 @@ def cli(  # pylint: disable=too-many-arguments
     buckets,
     log_level,
     broker_ssl_option,
+    worker_timeout,
 ):  # pylint: disable=unused-argument
     formatted_buckets = list(map(float, buckets.split(",")))
     ctx = click.get_current_context()
-    Exporter(formatted_buckets).run(ctx.params)
+    Exporter(formatted_buckets, worker_timeout).run(ctx.params)

--- a/src/cli.py
+++ b/src/cli.py
@@ -70,8 +70,9 @@ default_buckets_str = ",".join(map(str, Histogram.DEFAULT_BUCKETS))
     "--worker-timeout",
     default=5*60,
     show_default=True,
-    help="If no heartbeat has been recieved for a worker in this many seconds, "
-         "that a worker will be considered dead.",
+    help="If no heartbeat has been recieved from a worker in this many seconds, "
+         "that a worker will be considered dead. If set to 0, workers will never "
+         "be timed out",
 )
 def cli(  # pylint: disable=too-many-arguments
     broker_url,

--- a/src/cli.py
+++ b/src/cli.py
@@ -68,11 +68,11 @@ default_buckets_str = ",".join(map(str, Histogram.DEFAULT_BUCKETS))
 @click.option("--log-level", default="INFO", show_default=True)
 @click.option(
     "--worker-timeout",
-    default=5*60,
+    default=5 * 60,
     show_default=True,
     help="If no heartbeat has been recieved from a worker in this many seconds, "
-         "that a worker will be considered dead. If set to 0, workers will never "
-         "be timed out",
+    "that a worker will be considered dead. If set to 0, workers will never be "
+    "timed out",
 )
 def cli(  # pylint: disable=too-many-arguments
     broker_url,

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -17,7 +17,7 @@ from .http_server import start_http_server
 class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branches
     state: State = None
 
-    def __init__(self, buckets=None, worker_timeout_seconds=5*60):
+    def __init__(self, buckets=None, worker_timeout_seconds=5 * 60):
         self.registry = CollectorRegistry(auto_describe=True)
         self.queue_cache = set()
         self.worker_last_seen = {}
@@ -122,8 +122,12 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
                 )
                 self.celery_worker_up.labels(hostname=hostname).set(0)
                 self.worker_tasks_active.labels(hostname=hostname).set(0)
-                logger.debug("Updated gauge='{}' value='{}'", self.worker_tasks_active._name, 0)
-                logger.debug("Updated gauge='{}' value='{}'", self.celery_worker_up._name, 0)
+                logger.debug(
+                    "Updated gauge='{}' value='{}'", self.worker_tasks_active._name, 0
+                )
+                logger.debug(
+                    "Updated gauge='{}' value='{}'", self.celery_worker_up._name, 0
+                )
 
                 del self.worker_last_seen[hostname]
 
@@ -210,7 +214,7 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
         self.celery_worker_up.labels(hostname=hostname).set(value)
 
         if is_online:
-            self.worker_last_seen[hostname] = event['timestamp']
+            self.worker_last_seen[hostname] = event["timestamp"]
         else:
             del self.worker_last_seen[hostname]
             self.worker_tasks_active.labels(hostname=hostname).set(0)
@@ -219,7 +223,7 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
         hostname = get_hostname(event["hostname"])
         logger.debug("Received event='{}' for worker='{}'", event["type"], hostname)
 
-        self.worker_last_seen[hostname] = event['timestamp']
+        self.worker_last_seen[hostname] = event["timestamp"]
         worker_state = self.state.event(event)[0][0]
         active = worker_state.active or 0
         up = 1 if worker_state.alive else 0

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -106,6 +106,11 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
         )
 
     def scrape(self):
+        if self.worker_timeout_seconds > 0:
+            self.track_timed_out_workers()
+        self.track_queue_metrics()
+
+    def track_timed_out_workers(self):
         now = time.time()
         # Make a copy of the last seen dict so we can delete from the dict with no issues
         for hostname, last_seen in list(self.worker_last_seen.items()):
@@ -121,8 +126,6 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
                 logger.debug("Updated gauge='{}' value='{}'", self.celery_worker_up._name, 0)
 
                 del self.worker_last_seen[hostname]
-
-        self.track_queue_metrics()
 
     def track_queue_metrics(self):
         with self.app.connection() as connection:  # type: ignore


### PR DESCRIPTION
Fixes #228.

In that issue a worker timeout was discussed but it was believed that a separate thread would be needed to implement it. In this PR I take the approach of removing the expired workers on the Prometheus scrape avoiding the need for an additional thread.

I have added a cli option to specify the time frame with a default of 5 minutes. I've also added the ability for users to stick to the old functionality by turning this parameter to 0. 