### PR TITLE
Add Liveness and readiness probe timeout values

### DIFF
--- a/charts/celery-exporter/README.md
+++ b/charts/celery-exporter/README.md
@@ -55,4 +55,11 @@ Prometheus exporter for Celery
 | serviceMonitor.scrapeInterval | string | `"30s"` |  |
 | serviceMonitor.targetLabels | list | `[]` |  |
 | tolerations | list | `[]` |  |
-
+| livenessProbe.timeoutSeconds | object | `5` |  |
+| livenessProbe.failureThreshold | object | `5` |  |
+| livenessProbe.periodSeconds | object | `10` |  |
+| livenessProbe.successThreshold | object | `1` |  |
+| readinessProbe.timeoutSeconds | object | `5` |  |
+| readinessProbe.failureThreshold | object | `5` |  |
+| readinessProbe.periodSeconds | object | `10` |  |
+| readinessProbe.namespaceSelector | object | `1` |  |

--- a/charts/celery-exporter/templates/deployment.yaml
+++ b/charts/celery-exporter/templates/deployment.yaml
@@ -39,6 +39,18 @@ spec:
             httpGet:
               path: /health
               port: http
+              timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds | default "5" }}
+              failureThreshold: {{ .Values.livenessProbe.failureThreshold | default "5" }}
+              periodSeconds: {{ .Values.livenessProbe.periodSeconds | default "10" }}
+              successThreshold: {{ .Values.livenessProbe.successThreshold | default "1" }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+              timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds | default "5" }}
+              failureThreshold: {{ .Values.livenessProbe.failureThreshold | default "5" }}
+              periodSeconds: {{ .Values.livenessProbe.periodSeconds | default "10" }}
+              successThreshold: {{ .Values.livenessProbe.successThreshold | default "1" }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- with .Values.env }}

--- a/charts/celery-exporter/values.yaml
+++ b/charts/celery-exporter/values.yaml
@@ -94,6 +94,18 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+livenessProbe: {}
+  # Liveness and readiness probe timeout values.
+  # timeoutSeconds: 5
+  # failureThreshold: 5
+  # periodSeconds: 10
+  # successThreshold: 1
+readinessProbe: {}
+  # timeoutSeconds: 15
+  # failureThreshold: 5
+  # periodSeconds: 10
+  # successThreshold: 1
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
Added "Liveness and readiness probe timeout values" in values.yaml - To be able to change the timeout values.
```
    # Liveness and readiness probe timeout values.
    livenessProbe: {}
    #  timeoutSeconds: 5
    #  failureThreshold: 5
    #  periodSeconds: 10
    #  successThreshold: 1
    readinessProbe: {}
    #  timeoutSeconds: 15
    #  failureThreshold: 5
    #  periodSeconds: 10
    #  successThreshold: 1
```