### PR TITLE
Use Inspect object to get consumer count in a broker agnostic way

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ celery_worker_tasks_active | The number of tasks the worker is currently process
 celery_task_runtime_bucket | Histogram of runtime measurements for each task | Histogram
 celery_queue_length | The number of message in broker queue | Gauge
 celery_active_consumer_count | The number of active consumer in broker queue **(Only work for [RabbitMQ and Qpid](https://qpid.apache.org/) broker, more details at [here](https://github.com/danihodovic/celery-exporter/pull/118#issuecomment-1169870481))** | Gauge
+celery_active_worker_count | The number of active workers in broker queue | Gauge
+celery_active_process_count | The number of active process in broker queue. Each worker may have more than one process. | Gauge
 
 Used in production at [https://findwork.dev](https://findwork.dev) and [https://django.wtf](https://django.wtf).
 


### PR DESCRIPTION
This PR extends the `celery_active_consumer_count` metric beyond the currently supported brokers by using the Inspect object's `stat` method, and using the number of worker thread PID's returned as the amount of consumers on that worker. It then cross references that with the queues that worker is consuming from to create an amount of threads that could be working from that queue.

I'm not 100% sure of the terminology used. It could be that "active consumers" are intended to be the amount of workers, rather than the total amount of threads, or it could be that "active" is intended to mean the amount of threads currently working on tasks from that queue. I haven't been able to find good documentation on that in the celery, kombu, RabbitMQ, or Qpid documentation.