### PR TITLE
Support amqps transport for queue length tracking

### DIFF
--- a/src/exporter.py
+++ b/src/exporter.py
@@ -139,7 +139,12 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
         with self.app.connection() as connection:  # type: ignore
             transport = connection.info()["transport"]
             acceptable_transports = [
-                "redis", "rediss", "amqp", "amqps", "memory", "sentinel",
+                "redis",
+                "rediss",
+                "amqp",
+                "amqps",
+                "memory",
+                "sentinel",
             ]
             if transport not in acceptable_transports:
                 logger.debug(

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -138,7 +138,9 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
     def track_queue_metrics(self):
         with self.app.connection() as connection:  # type: ignore
             transport = connection.info()["transport"]
-            acceptable_transports = ["redis", "rediss", "amqp", "amqps", "memory", "sentinel"]
+            acceptable_transports = [
+                "redis", "rediss", "amqp", "amqps", "memory", "sentinel",
+            ]
             if transport not in acceptable_transports:
                 logger.debug(
                     f"Queue length tracking is only implemented for {acceptable_transports}"

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -138,7 +138,7 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
     def track_queue_metrics(self):
         with self.app.connection() as connection:  # type: ignore
             transport = connection.info()["transport"]
-            acceptable_transports = ["redis", "rediss", "amqp", "memory", "sentinel"]
+            acceptable_transports = ["redis", "rediss", "amqp", "amqps", "memory", "sentinel"]
             if transport not in acceptable_transports:
                 logger.debug(
                     f"Queue length tracking is only implemented for {acceptable_transports}"
@@ -160,7 +160,7 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
                 if transport in ["redis", "rediss", "sentinel"]:
                     queue_length = redis_queue_length(connection, queue)
                     track_length(queue, queue_length)
-                elif transport in ["amqp", "memory"]:
+                elif transport in ["amqp", "amqps", "memory"]:
                     queue_length = rabbitmq_queue_length(connection, queue)
                     track_length(queue, queue_length)
 


### PR DESCRIPTION
Currently queue length tracking is disabled for connection strings that use the `amqps` (amqp with ssl) transport. 

This PR adds "amqps" to the list of acceptable transports for queue length tracking (since it's allowed for amqp).