### PR TITLE
fix: Remove p99.9 queries from overviews

### DIFF
--- a/celery-mixin/dashboards/celery-tasks-overview.libsonnet
+++ b/celery-mixin/dashboards/celery-tasks-overview.libsonnet
@@ -504,7 +504,6 @@ local paginateTable = {
     ||| % $._config,
     local tasksRuntimeP95Query = std.strReplace(tasksRuntimeP50Query, '0.50', '0.95'),
     local tasksRuntimeP99Query = std.strReplace(tasksRuntimeP50Query, '0.50', '0.99'),
-    local tasksRuntimeP999Query = std.strReplace(tasksRuntimeP50Query, '0.50', '0.999'),
 
     local tasksRuntimeGraphPanel =
       grafana.graphPanel.new(
@@ -536,12 +535,6 @@ local paginateTable = {
         prometheus.target(
           tasksRuntimeP99Query,
           legendFormat='99',
-        )
-      )
-      .addTarget(
-        prometheus.target(
-          tasksRuntimeP999Query,
-          legendFormat='99.9',
         )
       ),
 

--- a/celery-mixin/dashboards_out/celery-tasks-overview.json
+++ b/celery-mixin/dashboards_out/celery-tasks-overview.json
@@ -941,13 +941,6 @@
                "intervalFactor": 2,
                "legendFormat": "99",
                "refId": "C"
-            },
-            {
-               "expr": "histogram_quantile(0.999,\n  sum(\n    irate(\n      celery_task_runtime_bucket{\n        job=~\"celery|celery-exporter\",\n        queue_name=~\"$queue_name\"\n      }[$__rate_interval]\n    ) > 0\n  ) by (job, le)\n)\n",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "99.9",
-               "refId": "D"
             }
          ],
          "thresholds": [ ],


### PR DESCRIPTION
Too many bucket queries == slow loads
