### PR TITLE
Make exporter work with eventlet concurrency

### DIFF
--- a/src/exporter.py
+++ b/src/exporter.py
@@ -215,7 +215,7 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
                 return
 
             concurrency_per_worker = {
-                worker: len(stats["pool"]["processes"])
+                worker: len(stats["pool"].get("processes", []))
                 for worker, stats in (self.app.control.inspect().stats() or {}).items()
             }
             processes_per_queue = defaultdict(int)


### PR DESCRIPTION
If any other Celery concurrency method is used other than `prefork` the `pool` `processes` information might not be available, resulting in a failure when scraping metrics. This PR makes sure the processes are only counted for `prefork`.