### PR TITLE
Allow queue cache to be initialized from the command line

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -70,7 +70,6 @@ def find_free_port():
     """
 
     def _find_free_port():
-
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         s.bind(("0.0.0.0", 0))
@@ -95,7 +94,7 @@ def exporter_instance(find_free_port, celery_config, log_level):
         "accept_content": None,
         "worker_timeout": 1,
         "purge_offline_worker_metrics": 10,
-        "initial_queues": ['queue_from_command_line'],
+        "initial_queues": ["queue_from_command_line"],
     }
     exporter = Exporter(
         worker_timeout_seconds=cfg["worker_timeout"],

--- a/conftest.py
+++ b/conftest.py
@@ -95,10 +95,12 @@ def exporter_instance(find_free_port, celery_config, log_level):
         "accept_content": None,
         "worker_timeout": 1,
         "purge_offline_worker_metrics": 10,
+        "initial_queues": ['queue_from_command_line'],
     }
     exporter = Exporter(
         worker_timeout_seconds=cfg["worker_timeout"],
         purge_offline_worker_metrics_seconds=cfg["purge_offline_worker_metrics"],
+        initial_queues=cfg["initial_queues"],
     )
     setattr(exporter, "cfg", cfg)
     yield exporter

--- a/src/cli.py
+++ b/src/cli.py
@@ -14,6 +14,12 @@ click.core._verify_python3_env = lambda: None  # type: ignore
 default_buckets_str = ",".join(map(str, Histogram.DEFAULT_BUCKETS))
 
 
+def _comma_seperated_argument(_ctx, _param, value):
+    if value is not None:
+        return value.split(",")
+    return []
+
+
 @click.command(help=cmd_help)
 @click.option(
     "--broker-url",
@@ -93,7 +99,17 @@ default_buckets_str = ",".join(map(str, Histogram.DEFAULT_BUCKETS))
     "Knowing which client sent a task might not be useful for many use cases as for example in "
     "Kubernetes environments where the client's hostname is a random string.",
 )
-def cli(  # pylint: disable=too-many-arguments
+@click.option(
+    "-Q",
+    "--queues",
+    default=None,
+    show_default=False,
+    callback=_comma_seperated_argument,
+    help="A comma seperated list of queues to force metrics to appear for. "
+    "Queues not included in this setting will not appear in metrics until at least one worker has "
+    "been seen to follow that queue.",
+)
+def cli(  # pylint: disable=too-many-arguments,too-many-locals
     broker_url,
     broker_transport_option,
     accept_content,
@@ -106,6 +122,7 @@ def cli(  # pylint: disable=too-many-arguments
     worker_timeout,
     purge_offline_worker_metrics,
     generic_hostname_task_sent_metric,
+    queues,
 ):  # pylint: disable=unused-argument
     formatted_buckets = list(map(float, buckets.split(",")))
     ctx = click.get_current_context()
@@ -114,4 +131,5 @@ def cli(  # pylint: disable=too-many-arguments
         worker_timeout,
         purge_offline_worker_metrics,
         generic_hostname_task_sent_metric,
+        queues,
     ).run(ctx.params)

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -20,15 +20,17 @@ from .http_server import start_http_server
 class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branches
     state: State = None
 
+    # pylint: disable=too-many-arguments
     def __init__(
         self,
         buckets=None,
         worker_timeout_seconds=5 * 60,
         purge_offline_worker_metrics_seconds=10 * 60,
         generic_hostname_task_sent_metric=False,
+        initial_queues=None,
     ):
         self.registry = CollectorRegistry(auto_describe=True)
-        self.queue_cache = set()
+        self.queue_cache = set(initial_queues or [])
         self.worker_last_seen = {}
         self.worker_timeout_seconds = worker_timeout_seconds
         self.purge_offline_worker_metrics_after_seconds = (

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -451,7 +451,9 @@ def redis_queue_length(connection, queue: str) -> int:
 
 
 def rabbitmq_queue_length(connection, queue: str) -> int:
-    return rabbitmq_queue_info(connection, queue).message_count
+    if queue_info := rabbitmq_queue_info(connection, queue):
+        return queue_info.message_count
+    return 0
 
 
 def queue_length(transport, connection, queue: str) -> Optional[int]:
@@ -465,7 +467,9 @@ def queue_length(transport, connection, queue: str) -> Optional[int]:
 
 
 def rabbitmq_queue_consumer_count(connection, queue: str) -> int:
-    return rabbitmq_queue_info(connection, queue).consumer_count
+    if queue_info := rabbitmq_queue_info(connection, queue):
+        return queue_info.consumer_count
+    return 0
 
 
 def rabbitmq_queue_info(connection, queue: str):
@@ -475,5 +479,5 @@ def rabbitmq_queue_info(connection, queue: str):
     except ChannelError as ex:
         if "NOT_FOUND" in ex.message:
             logger.debug(f"Queue '{queue}' not found")
-            return 0
+            return None
         raise ex


### PR DESCRIPTION
# Motivation

We are running celery-exporter in a kubernetes environment and using the metrics it provides to scale the number of workers. Sometimes we scale the number of workers down to zero automatically e.g test environments out of office hours for instance.

When there are no workers, if celery-exporter stops for any reason (e.g. kubernetes moves it to a different node), celery-exporter stops reporting metrics for the queues as it has no way of knowing what the queues are. In our case this means we can never automatically scale back up as the metrics are missing.

As we know all of the queues we wish to be following in advance, being able to tell celery-exporter all the queues we wish to have metrics for is a useful feature.

## Implementation

Implementation is straight forward as there is already the `queue_cache` to deal with the case that workers go away while celery-exporter is running, so all we need to do is prefill that cache.

I've chosen to use `-Q` and `--queues` as the command line arguments to match the celery command line.