### PR TITLE
Build docker image to run with non root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,10 @@ RUN apt-get update && \
     && poetry config virtualenvs.create false \
     && poetry install --no-interaction \
     && rm -rf /root/.cache \
-    && apt remove -y build-essential
+    && apt remove -y build-essential \
+    && adduser --disabled-login exporter
+
+USER exporter
 
 COPY . /app/
 


### PR DESCRIPTION
Want to ensure that containers running in my cluster aren't running as root. Creating a new user in the container `exporter` and changing the image to run with that user. 