### PR TITLE
fix: Use event timestamp based on utcoffset

### DIFF
--- a/src/test_metrics.py
+++ b/src/test_metrics.py
@@ -3,6 +3,9 @@ import time
 
 import pytest
 from celery.contrib.testing.worker import start_worker  # type: ignore
+from celery.utils.time import adjust_timestamp  # type: ignore
+
+from src.exporter import reverse_adjust_timestamp
 
 
 @pytest.fixture
@@ -70,9 +73,22 @@ def test_worker_status(threaded_exporter, celery_app, hostname):
     )
 
 
-def test_worker_timeout_status(threaded_exporter, hostname):
-    ts = time.time()
-    threaded_exporter.track_worker_status({"hostname": hostname, "timestamp": ts}, True)
+@pytest.mark.parametrize(
+    "input_utcoffset, sleep_seconds, expected_metric_value",
+    [
+        (None, 5, 0.0),
+        (0, 5, 0.0),
+        (7, 5, 0.0),
+        (7, 0, 1.0),
+    ],  # Eg: PST (America/Los_Angeles)
+)
+def test_worker_timeout_status(
+    input_utcoffset, sleep_seconds, expected_metric_value, threaded_exporter, hostname
+):
+    ts = adjust_timestamp(time.time(), (input_utcoffset or 0))
+    threaded_exporter.track_worker_status(
+        {"hostname": hostname, "timestamp": ts, "utcoffset": input_utcoffset}, True
+    )
     assert (
         threaded_exporter.registry.get_sample_value(
             "celery_worker_up", labels={"hostname": hostname}
@@ -81,22 +97,35 @@ def test_worker_timeout_status(threaded_exporter, hostname):
     )
     assert threaded_exporter.worker_last_seen[hostname] == {
         "forgotten": False,
-        "ts": ts,
+        "ts": reverse_adjust_timestamp(ts, input_utcoffset),
     }
 
-    time.sleep(5)
+    time.sleep(sleep_seconds)
     threaded_exporter.scrape()
     assert (
         threaded_exporter.registry.get_sample_value(
             "celery_worker_up", labels={"hostname": hostname}
         )
-        == 0.0
+        == expected_metric_value
     )
 
 
-def test_purge_offline_worker_metrics(threaded_exporter, hostname):
-    ts = time.time()
-    threaded_exporter.track_worker_status({"hostname": hostname, "timestamp": ts}, True)
+@pytest.mark.parametrize(
+    "input_utcoffset, sleep_seconds, expected_metric_value",
+    [
+        (None, 15, None),
+        (0, 15, None),
+        (7, 15, None),
+        (7, 0, 1.0),
+    ],  # Eg: PST (America/Los_Angeles)
+)
+def test_purge_offline_worker_metrics(
+    input_utcoffset, sleep_seconds, expected_metric_value, threaded_exporter, hostname
+):
+    ts = adjust_timestamp(time.time(), (input_utcoffset or 0))
+    threaded_exporter.track_worker_status(
+        {"hostname": hostname, "timestamp": ts, "utcoffset": input_utcoffset}, True
+    )
     threaded_exporter.worker_tasks_active.labels(hostname=hostname).inc()
     threaded_exporter.celery_task_runtime.labels(
         name="boosh", hostname=hostname, queue_name="test"
@@ -134,36 +163,36 @@ def test_purge_offline_worker_metrics(threaded_exporter, hostname):
 
     assert threaded_exporter.worker_last_seen[hostname] == {
         "forgotten": False,
-        "ts": ts,
+        "ts": reverse_adjust_timestamp(ts, input_utcoffset),
     }
 
-    time.sleep(15)
+    time.sleep(sleep_seconds)
     threaded_exporter.scrape()
     assert (
         threaded_exporter.registry.get_sample_value(
             "celery_worker_up", labels={"hostname": hostname}
         )
-        is None
+        == expected_metric_value
     )
     assert (
         threaded_exporter.registry.get_sample_value(
             "celery_worker_tasks_active", labels={"hostname": hostname}
         )
-        is None
+        == expected_metric_value
     )
     assert (
         threaded_exporter.registry.get_sample_value(
             "celery_task_runtime_count",
             labels={"hostname": hostname, "queue_name": "test", "name": "boosh"},
         )
-        is None
+        == expected_metric_value
     )
     assert (
         threaded_exporter.registry.get_sample_value(
             "celery_task_sent_total",
             labels={"hostname": hostname, "queue_name": "test", "name": "boosh"},
         )
-        is None
+        == expected_metric_value
     )
 
 


### PR DESCRIPTION
celery-exporter has this [feature](https://github.com/danihodovic/celery-exporter/pull/248) to purge ofline worker metrics which default to 10 minutes. So any worker that is offline for more than 10 minutes, the metrics of which will be purged
Now if celery workers is configured to use PST timezone (which is 7 hours behind UTC) or any other timezone that is not UTC, in such cases celery-exporter (running in UTC tz) considered live workers also to be offline because of this offset and this causes a continuous loop of live worker metrics to be purged and so we get inconsistent metrics.

Temp solution is to set `CE_WORKER_TIMEOUT` and `CE_PURGE_OFFLINE_WORKER_METRICS` to 7hrs + 10mins ahead 