### PR TITLE
fix: celerySelector filter

### DIFF
--- a/celery-mixin/config.libsonnet
+++ b/celery-mixin/config.libsonnet
@@ -4,7 +4,7 @@ local annotation = g.dashboard.annotation;
 {
   _config+:: {
     // Selectors are inserted between {} in Prometheus queries.
-    celerySelector: 'job=~"celery|celery-exporter"',
+    celerySelector: 'job=~".*celery.*"',
 
     grafanaUrl: 'https://grafana.com',
 

--- a/celery-mixin/dashboards_out/celery-tasks-by-task.json
+++ b/celery-mixin/dashboards_out/celery-tasks-by-task.json
@@ -68,7 +68,7 @@
                }
             ]
          },
-         "pluginVersion": "v11.0.0",
+         "pluginVersion": "v11.1.0",
          "targets": [
             {
                "datasource": {
@@ -209,7 +209,7 @@
                }
             ]
          },
-         "pluginVersion": "v11.0.0",
+         "pluginVersion": "v11.1.0",
          "targets": [
             {
                "datasource": {
@@ -281,7 +281,7 @@
                "sort": "desc"
             }
          },
-         "pluginVersion": "v11.0.0",
+         "pluginVersion": "v11.1.0",
          "targets": [
             {
                "datasource": {
@@ -380,7 +380,7 @@
                "sort": "desc"
             }
          },
-         "pluginVersion": "v11.0.0",
+         "pluginVersion": "v11.1.0",
          "targets": [
             {
                "datasource": {
@@ -478,7 +478,7 @@
                "sort": "desc"
             }
          },
-         "pluginVersion": "v11.0.0",
+         "pluginVersion": "v11.1.0",
          "targets": [
             {
                "datasource": {

--- a/celery-mixin/dashboards_out/celery-tasks-overview.json
+++ b/celery-mixin/dashboards_out/celery-tasks-overview.json
@@ -61,7 +61,7 @@
                ]
             }
          },
-         "pluginVersion": "v11.0.0",
+         "pluginVersion": "v11.1.0",
          "targets": [
             {
                "datasource": {
@@ -110,7 +110,7 @@
                ]
             }
          },
-         "pluginVersion": "v11.0.0",
+         "pluginVersion": "v11.1.0",
          "targets": [
             {
                "datasource": {
@@ -159,7 +159,7 @@
                ]
             }
          },
-         "pluginVersion": "v11.0.0",
+         "pluginVersion": "v11.1.0",
          "targets": [
             {
                "datasource": {
@@ -212,7 +212,7 @@
                ]
             }
          },
-         "pluginVersion": "v11.0.0",
+         "pluginVersion": "v11.1.0",
          "targets": [
             {
                "datasource": {
@@ -261,7 +261,7 @@
                ]
             }
          },
-         "pluginVersion": "v11.0.0",
+         "pluginVersion": "v11.1.0",
          "targets": [
             {
                "datasource": {
@@ -323,7 +323,7 @@
                }
             ]
          },
-         "pluginVersion": "v11.0.0",
+         "pluginVersion": "v11.1.0",
          "targets": [
             {
                "datasource": {
@@ -384,7 +384,7 @@
                }
             ]
          },
-         "pluginVersion": "v11.0.0",
+         "pluginVersion": "v11.1.0",
          "targets": [
             {
                "datasource": {
@@ -466,7 +466,7 @@
                }
             ]
          },
-         "pluginVersion": "v11.0.0",
+         "pluginVersion": "v11.1.0",
          "targets": [
             {
                "datasource": {
@@ -548,7 +548,7 @@
                "sort": "desc"
             }
          },
-         "pluginVersion": "v11.0.0",
+         "pluginVersion": "v11.1.0",
          "targets": [
             {
                "datasource": {
@@ -614,7 +614,7 @@
                }
             ]
          },
-         "pluginVersion": "v11.0.0",
+         "pluginVersion": "v11.1.0",
          "targets": [
             {
                "datasource": {
@@ -764,7 +764,7 @@
                "sort": "desc"
             }
          },
-         "pluginVersion": "v11.0.0",
+         "pluginVersion": "v11.1.0",
          "targets": [
             {
                "datasource": {
@@ -910,7 +910,7 @@
                "sort": "desc"
             }
          },
-         "pluginVersion": "v11.0.0",
+         "pluginVersion": "v11.1.0",
          "targets": [
             {
                "datasource": {


### PR DESCRIPTION
When deploying kube-prometheus and using PodMonitors the resulting job
name is "<namespace>/celery-exporter". This job name fails the regex
filter applied in the Grafana dashboard.
