### PR TITLE
Automatically push to ghcr and build for ARM

### DIFF
--- a/.github/workflows/push-image-ghcr.yml
+++ b/.github/workflows/push-image-ghcr.yml
@@ -49,6 +49,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           provenance: false
           push: true
-          tags: ${{ steps.meta.outputs.tags }}${{ github.ref_name }}
+          tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/push-image-ghcr.yml
+++ b/.github/workflows/push-image-ghcr.yml
@@ -1,0 +1,54 @@
+name: Create and publish a Docker image to ghcr.io
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,enable=true,priority=100,prefix=,suffix=,format=short
+            type=semver,pattern={{version}},value=${{ github.ref_name }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}${{ github.ref_name }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
If there is a new tag created, github actions builds for multiarch (including ARM) and pushes to GHCR.

Closes:
- https://github.com/danihodovic/celery-exporter/issues/171

Probably closes:
- https://github.com/danihodovic/celery-exporter/issues/35
