### PR TITLE
feat: Ability to add labels with constant values

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -19,6 +19,16 @@ def _comma_seperated_argument(_ctx, _param, value):
         return value.split(",")
     return []
 
+# Accepts value string in format "key=val". Returns dict {key: val}.
+# * If value is None - returns empty dict
+def _eq_sign_separated_argument_to_dict(_ctx, _param, value):
+    if value is not None:
+        dict_of_key_value_pairs = {}
+        for key_value_pair in value:
+            key, val = key_value_pair.split("=")
+            dict_of_key_value_pairs[key] = val
+        return dict_of_key_value_pairs
+    return {}
 
 @click.command(help=cmd_help)
 @click.option(
@@ -115,6 +125,14 @@ def _comma_seperated_argument(_ctx, _param, value):
     help="Prefix all metrics with a string. "
     "This option replaces the 'celery_*' part with a custom prefix. ",
 )
+@click.option(
+    "--static-label",
+    required=False,
+    default=None,
+    multiple=True,
+    callback=_eq_sign_separated_argument_to_dict,
+    help="Add label with static value to all metrics",
+)
 def cli(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
     broker_url,
     broker_transport_option,
@@ -130,6 +148,7 @@ def cli(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too
     generic_hostname_task_sent_metric,
     queues,
     metric_prefix,
+    static_label,
 ):  # pylint: disable=unused-argument
     formatted_buckets = list(map(float, buckets.split(",")))
     ctx = click.get_current_context()
@@ -140,4 +159,5 @@ def cli(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too
         generic_hostname_task_sent_metric,
         queues,
         metric_prefix,
+        static_label
     ).run(ctx.params)

--- a/src/cli.py
+++ b/src/cli.py
@@ -19,6 +19,7 @@ def _comma_seperated_argument(_ctx, _param, value):
         return value.split(",")
     return []
 
+
 # Accepts value string in format "key=val". Returns dict {key: val}.
 # * If value is None - returns empty dict
 def _eq_sign_separated_argument_to_dict(_ctx, _param, value):
@@ -29,6 +30,7 @@ def _eq_sign_separated_argument_to_dict(_ctx, _param, value):
             dict_of_key_value_pairs[key] = val
         return dict_of_key_value_pairs
     return {}
+
 
 @click.command(help=cmd_help)
 @click.option(
@@ -159,5 +161,5 @@ def cli(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too
         generic_hostname_task_sent_metric,
         queues,
         metric_prefix,
-        static_label
+        static_label,
     ).run(ctx.params)

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -29,6 +29,7 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
         generic_hostname_task_sent_metric=False,
         initial_queues=None,
         metric_prefix="celery_",
+        static_label=[]
     ):
         self.registry = CollectorRegistry(auto_describe=True)
         self.queue_cache = set(initial_queues or [])
@@ -38,98 +39,103 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
             purge_offline_worker_metrics_seconds
         )
         self.generic_hostname_task_sent_metric = generic_hostname_task_sent_metric
+        
+        # Static labels
+        self.static_label = static_label
+        self.static_label_keys = static_label.keys()
+
         self.state_counters = {
             "task-sent": Counter(
                 f"{metric_prefix}task_sent",
                 "Sent when a task message is published.",
-                ["name", "hostname", "queue_name"],
+                ["name", "hostname", "queue_name", *self.static_label_keys],
                 registry=self.registry,
             ),
             "task-received": Counter(
                 f"{metric_prefix}task_received",
                 "Sent when the worker receives a task.",
-                ["name", "hostname", "queue_name"],
+                ["name", "hostname", "queue_name", *self.static_label_keys],
                 registry=self.registry,
             ),
             "task-started": Counter(
                 f"{metric_prefix}task_started",
                 "Sent just before the worker executes the task.",
-                ["name", "hostname", "queue_name"],
+                ["name", "hostname", "queue_name", *self.static_label_keys],
                 registry=self.registry,
             ),
             "task-succeeded": Counter(
                 f"{metric_prefix}task_succeeded",
                 "Sent if the task executed successfully.",
-                ["name", "hostname", "queue_name"],
+                ["name", "hostname", "queue_name", *self.static_label_keys],
                 registry=self.registry,
             ),
             "task-failed": Counter(
                 f"{metric_prefix}task_failed",
                 "Sent if the execution of the task failed.",
-                ["name", "hostname", "exception", "queue_name"],
+                ["name", "hostname", "exception", "queue_name", *self.static_label_keys],
                 registry=self.registry,
             ),
             "task-rejected": Counter(
                 f"{metric_prefix}task_rejected",
                 # pylint: disable=line-too-long
                 "The task was rejected by the worker, possibly to be re-queued or moved to a dead letter queue.",
-                ["name", "hostname", "queue_name"],
+                ["name", "hostname", "queue_name", *self.static_label_keys],
                 registry=self.registry,
             ),
             "task-revoked": Counter(
                 f"{metric_prefix}task_revoked",
                 "Sent if the task has been revoked.",
-                ["name", "hostname", "queue_name"],
+                ["name", "hostname", "queue_name", *self.static_label_keys],
                 registry=self.registry,
             ),
             "task-retried": Counter(
                 f"{metric_prefix}task_retried",
                 "Sent if the task failed, but will be retried in the future.",
-                ["name", "hostname", "queue_name"],
+                ["name", "hostname", "queue_name", *self.static_label_keys],
                 registry=self.registry,
             ),
         }
         self.celery_worker_up = Gauge(
             f"{metric_prefix}worker_up",
             "Indicates if a worker has recently sent a heartbeat.",
-            ["hostname"],
+            ["hostname", *self.static_label_keys],
             registry=self.registry,
         )
         self.worker_tasks_active = Gauge(
             f"{metric_prefix}worker_tasks_active",
             "The number of tasks the worker is currently processing",
-            ["hostname"],
+            ["hostname", *self.static_label_keys],
             registry=self.registry,
         )
         self.celery_task_runtime = Histogram(
             f"{metric_prefix}task_runtime",
             "Histogram of task runtime measurements.",
-            ["name", "hostname", "queue_name"],
+            ["name", "hostname", "queue_name", *self.static_label_keys],
             registry=self.registry,
             buckets=buckets or Histogram.DEFAULT_BUCKETS,
         )
         self.celery_queue_length = Gauge(
             f"{metric_prefix}queue_length",
             "The number of message in broker queue.",
-            ["queue_name"],
+            ["queue_name", *self.static_label_keys],
             registry=self.registry,
         )
         self.celery_active_consumer_count = Gauge(
             f"{metric_prefix}active_consumer_count",
             "The number of active consumer in broker queue.",
-            ["queue_name"],
+            ["queue_name", *self.static_label_keys],
             registry=self.registry,
         )
         self.celery_active_worker_count = Gauge(
             f"{metric_prefix}active_worker_count",
             "The number of active workers in broker queue.",
-            ["queue_name"],
+            ["queue_name", *self.static_label_keys],
             registry=self.registry,
         )
         self.celery_active_process_count = Gauge(
             f"{metric_prefix}active_process_count",
             "The number of active processes in broker queue.",
-            ["queue_name"],
+            ["queue_name", *self.static_label_keys],
             registry=self.registry,
         )
 
@@ -143,8 +149,8 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
 
     def forget_worker(self, hostname):
         if hostname in self.worker_last_seen:
-            self.celery_worker_up.labels(hostname=hostname).set(0)
-            self.worker_tasks_active.labels(hostname=hostname).set(0)
+            self.celery_worker_up.labels(hostname=hostname, **self.static_label).set(0)
+            self.worker_tasks_active.labels(hostname=hostname, **self.static_label).set(0)
             logger.debug(
                 "Updated gauge='{}' value='{}'", self.worker_tasks_active._name, 0
             )
@@ -238,19 +244,19 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
             for queue in self.queue_cache:
                 if transport in ["amqp", "amqps", "memory"]:
                     consumer_count = rabbitmq_queue_consumer_count(connection, queue)
-                    self.celery_active_consumer_count.labels(queue_name=queue).set(
+                    self.celery_active_consumer_count.labels(queue_name=queue, **self.static_label).set(
                         consumer_count
                     )
 
-                self.celery_active_process_count.labels(queue_name=queue).set(
+                self.celery_active_process_count.labels(queue_name=queue, **self.static_label).set(
                     processes_per_queue[queue]
                 )
-                self.celery_active_worker_count.labels(queue_name=queue).set(
+                self.celery_active_worker_count.labels(queue_name=queue, **self.static_label).set(
                     workers_per_queue[queue]
                 )
                 length = queue_length(transport, connection, queue)
                 if length is not None:
-                    self.celery_queue_length.labels(queue_name=queue).set(length)
+                    self.celery_queue_length.labels(queue_name=queue, **self.static_label).set(length)
 
     def track_task_event(self, event):
         self.state.event(event)
@@ -264,6 +270,7 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
             "name": task.name,
             "hostname": get_hostname(task.hostname),
             "queue_name": getattr(task, "queue", "celery"),
+            **self.static_label
         }
         if event["type"] == "task-sent" and self.generic_hostname_task_sent_metric:
             labels["hostname"] = "generic"
@@ -303,7 +310,7 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
         event_name = "worker-online" if is_online else "worker-offline"
         hostname = get_hostname(event["hostname"])
         logger.debug("Received event='{}' for hostname='{}'", event_name, hostname)
-        self.celery_worker_up.labels(hostname=hostname).set(value)
+        self.celery_worker_up.labels(hostname=hostname, **self.static_label).set(value)
 
         if is_online:
             self.worker_last_seen[hostname] = {
@@ -326,8 +333,8 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
         worker_state = self.state.event(event)[0][0]
         active = worker_state.active or 0
         up = 1 if worker_state.alive else 0
-        self.celery_worker_up.labels(hostname=hostname).set(up)
-        self.worker_tasks_active.labels(hostname=hostname).set(active)
+        self.celery_worker_up.labels(hostname=hostname, **self.static_label).set(up)
+        self.worker_tasks_active.labels(hostname=hostname, **self.static_label).set(active)
         logger.debug(
             "Updated gauge='{}' value='{}'", self.worker_tasks_active._name, active
         )

--- a/src/test_cli.py
+++ b/src/test_cli.py
@@ -115,3 +115,176 @@ def test_integration(broker, celery_app, threaded_exporter, hostname):
         assert 'celery_active_consumer_count{queue_name="celery"} 0.0' in res.text
     assert 'celery_active_worker_count{queue_name="celery"} 0.0' in res.text
     assert 'celery_active_process_count{queue_name="celery"} 0.0' in res.text
+
+
+# pylint: disable=too-many-statements
+@pytest.mark.celery()
+def test_integration_static_labels(
+    broker, celery_app, threaded_exporter_static_labels, hostname
+):
+    exporter_url = (
+        f"http://localhost:{threaded_exporter_static_labels.cfg['port']}/metrics"
+    )
+    # Substring representing static labels in metrics labels
+    static_labels_str = ",".join(
+        [
+            f'{k}="{v}"'
+            for k, v in sorted(
+                threaded_exporter_static_labels.cfg["static_label"].items()
+            )
+        ]
+    )
+
+    @celery_app.task
+    def succeed():
+        pass
+
+    @celery_app.task
+    def fail():
+        raise HTTPError("Intentional error")
+
+    time.sleep(1)
+    # Before the first worker starts, make sure queues that the exporter is initialized
+    # with are available anyway. Queues to be detected from workers should not be there yet
+    res = requests.get(exporter_url, timeout=5)
+    assert res.status_code == 200
+    assert (
+        f'celery_queue_length{{queue_name="queue_from_command_line",{static_labels_str}}} 0.0'
+        in res.text
+    )
+    assert (
+        # pylint: disable=line-too-long
+        f'celery_active_worker_count{{queue_name="queue_from_command_line",{static_labels_str}}} 0.0'
+        in res.text
+    )
+    assert (
+        # pylint: disable=line-too-long
+        f'celery_active_process_count{{queue_name="queue_from_command_line",{static_labels_str}}} 0.0'
+        in res.text
+    )
+    assert (
+        f'celery_queue_length{{queue_name="celery",{static_labels_str}}}'
+        not in res.text
+    )
+    assert (
+        f'celery_active_worker_count{{queue_name="celery",{static_labels_str}}}'
+        not in res.text
+    )
+    assert (
+        f'celery_active_process_count{{queue_name="celery",{static_labels_str}}}'
+        not in res.text
+    )
+
+    # start worker first so the exporter can fetch and cache queue information
+    with start_worker(celery_app, without_heartbeat=False):
+        time.sleep(5)
+        res = requests.get(exporter_url, timeout=5)
+        assert res.status_code == 200
+        assert (
+            f'celery_queue_length{{queue_name="celery",{static_labels_str}}} 0.0'
+            in res.text
+        ), res.text
+
+        # TODO: Fix this...
+        if broker == "memory":
+            assert (
+                f'celery_active_consumer_count{{queue_name="celery",{static_labels_str}}} 0.0'
+                in res.text
+            ), res.text
+        assert (
+            f'celery_active_worker_count{{queue_name="celery",{static_labels_str}}} 1.0'
+            in res.text
+        )
+        assert (
+            f'celery_active_process_count{{queue_name="celery",{static_labels_str}}} 1.0'
+            in res.text
+        )
+
+    succeed.apply_async()
+    succeed.apply_async()
+    fail.apply_async()
+
+    # assert celery_queue_length when message in broker but no worker start
+    res = requests.get(exporter_url, timeout=3)
+    assert res.status_code == 200
+    assert (
+        f'celery_queue_length{{queue_name="celery",{static_labels_str}}} 3.0'
+        in res.text
+    )
+
+    if broker == "memory":
+        assert (
+            f'celery_active_consumer_count{{queue_name="celery",{static_labels_str}}} 0.0'
+            in res.text
+        )
+    assert (
+        f'celery_active_worker_count{{queue_name="celery",{static_labels_str}}} 0.0'
+        in res.text
+    )
+    assert (
+        f'celery_active_process_count{{queue_name="celery",{static_labels_str}}} 0.0'
+        in res.text
+    )
+
+    # start worker and consume message in broker
+    with start_worker(celery_app, without_heartbeat=False):
+        time.sleep(2)
+
+    res = requests.get(exporter_url, timeout=3)
+    assert res.status_code == 200
+    # pylint: disable=line-too-long
+    assert (
+        f'celery_task_sent_total{{hostname="{hostname}",name="src.test_cli.succeed",queue_name="celery",{static_labels_str}}} 2.0'
+        in res.text
+    )
+    assert (
+        f'celery_task_sent_total{{hostname="{hostname}",name="src.test_cli.fail",queue_name="celery",{static_labels_str}}} 1.0'
+        in res.text
+    )
+    assert (
+        f'celery_task_received_total{{hostname="{hostname}",name="src.test_cli.succeed",queue_name="celery",{static_labels_str}}} 2.0'
+        in res.text
+    )
+    assert (
+        f'celery_task_received_total{{hostname="{hostname}",name="src.test_cli.fail",queue_name="celery",{static_labels_str}}} 1.0'
+        in res.text
+    )
+    assert (
+        f'celery_task_started_total{{hostname="{hostname}",name="src.test_cli.succeed",queue_name="celery",{static_labels_str}}} 2.0'
+        in res.text
+    )
+    assert (
+        f'celery_task_started_total{{hostname="{hostname}",name="src.test_cli.fail",queue_name="celery",{static_labels_str}}} 1.0'
+        in res.text
+    )
+    assert (
+        f'celery_task_succeeded_total{{hostname="{hostname}",name="src.test_cli.succeed",queue_name="celery",{static_labels_str}}} 2.0'
+        in res.text
+    )
+    assert (
+        f'celery_task_failed_total{{exception="HTTPError",hostname="{hostname}",name="src.test_cli.fail",queue_name="celery",{static_labels_str}}} 1.0'
+        in res.text
+    )
+    assert (
+        f'celery_task_runtime_count{{hostname="{hostname}",name="src.test_cli.succeed",queue_name="celery",{static_labels_str}}} 2.0'
+        in res.text
+    )
+    assert (
+        f'celery_queue_length{{queue_name="celery",{static_labels_str}}} 0.0'
+        in res.text
+    )
+
+    # TODO: Fix this...
+    if broker == "memory":
+        assert (
+            f'celery_active_consumer_count{{queue_name="celery",{static_labels_str}}} 0.0'
+            in res.text
+        )
+    assert (
+        f'celery_active_worker_count{{queue_name="celery",{static_labels_str}}} 0.0'
+        in res.text
+    )
+    assert (
+        f'celery_active_process_count{{queue_name="celery",{static_labels_str}}} 0.0'
+        in res.text
+    )


### PR DESCRIPTION
Example: we have application with different environments, each having its own exporter. We want to distinguish metrics by environment by label, not by metric prefix. So we need to provide exporter with an ability to attach custom labels to metrics.

Implemented as cli arg `--static-label`, that can be provided multiple times in format `--static-label key=value`

Example:  `python cli.py --broker-url=redis://127.0.0.1:6379 --static-label application=my-application-name --static-label environment=staging`

Here is the result:
![image_2024-12-05_13-28-19](https://github.com/user-attachments/assets/601d0ec0-2976-44cb-b194-739bbbcb700a)

Code changes: 
- New cli arg
- In the code where metrics are defined, there are `*self.static_label_keys` at the end to unpack provided static labels names
- In the code where we provide labels for metrics now there are `**self.static_label`, which unpack static labels and their values.