### PR TITLE
fix: typo error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ docker run -p 9808:9808 danihodovic/celery-exporter --broker-url=redis://redis.s
 Using the Python binary (for-non Docker environments):
 ```sh
 curl -L https://github.com/danihodovic/celery-exporter/releases/download/latest/celery-exporter -o ./celery-exporter
-chmod+x ./celery-exporter
+chmod +x ./celery-exporter
 ./celery-exporter --broker-url=redis://redis.service.consul/1
 ```
 


### PR DESCRIPTION
added space that allows that command to be pasted directly