### PR TITLE
Add queue latency histogram metric

### DIFF
--- a/src/exporter.py
+++ b/src/exporter.py
@@ -122,6 +122,13 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
             registry=self.registry,
             buckets=buckets or Histogram.DEFAULT_BUCKETS,
         )
+        self.celery_task_queue_latency = Histogram(
+            f"{metric_prefix}task_queue_latency",
+            "Time spent by task waiting in the queue (between task-sent and task-received).",
+            ["name", "queue_name", *self.static_label_keys],
+            registry=self.registry,
+            buckets=buckets or Histogram.DEFAULT_BUCKETS,
+        )
         self.celery_queue_length = Gauge(
             f"{metric_prefix}queue_length",
             "The number of message in broker queue.",
@@ -193,6 +200,10 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
         for label_seq in list(self.celery_task_runtime._metrics.keys()):
             if hostname in label_seq:
                 self.celery_task_runtime.remove(*label_seq)
+
+        for label_seq in list(self.celery_task_queue_latency._metrics.keys()):
+            if hostname in label_seq:
+                self.celery_task_queue_latency.remove(*label_seq)
 
         del self.worker_last_seen[hostname]
 
@@ -316,6 +327,27 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
                 labels,
                 task.runtime,
             )
+
+        # observe queue latency (time between sent and received)
+        if event["type"] == "task-received":
+            if hasattr(task, "sent") and task.sent is not None:
+                received_ts = event.get("timestamp") or task.received
+                wait_time = received_ts - task.sent
+                if wait_time >= 0:
+                    queue_latency_labels = {
+                        "name": task.name,
+                        "queue_name": getattr(task, "queue", self.default_queue_name),
+                        **self.static_label,
+                    }
+                    self.celery_task_queue_latency.labels(
+                        **queue_latency_labels
+                    ).observe(wait_time)
+                    logger.debug(
+                        "Observed metric='{}' labels='{}': {}s",
+                        self.celery_task_queue_latency._name,
+                        queue_latency_labels,
+                        wait_time,
+                    )
 
     def track_worker_status(self, event, is_online):
         value = 1 if is_online else 0

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -201,10 +201,6 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
             if hostname in label_seq:
                 self.celery_task_runtime.remove(*label_seq)
 
-        for label_seq in list(self.celery_task_queue_latency._metrics.keys()):
-            if hostname in label_seq:
-                self.celery_task_queue_latency.remove(*label_seq)
-
         del self.worker_last_seen[hostname]
 
     def track_timed_out_workers(self):

--- a/src/test_exporter.py
+++ b/src/test_exporter.py
@@ -1,4 +1,6 @@
-from .exporter import transform_option_value
+import time
+
+from .exporter import Exporter, transform_option_value
 
 
 def test_transform_option_value():
@@ -14,3 +16,89 @@ def test_transform_option_value():
 
     for case in test_cases:
         assert transform_option_value(case["input"]) == case["expected"]
+
+
+def _make_task_event(uuid, event_type, timestamp, hostname="worker@host",
+                     name="dummy_task", queue="default"):
+    """Helper to create a valid Celery task event with required fields."""
+    return {
+        "uuid": uuid,
+        "type": event_type,
+        "timestamp": timestamp,
+        "local_received": timestamp,
+        "clock": 0,
+        "hostname": hostname,
+        "name": name,
+        "queue": queue,
+    }
+
+
+def test_queue_latency_metric():
+    """Test that queue latency is measured between task-sent and task-received."""
+    from celery import Celery
+
+    app = Celery(broker="memory://")
+    exporter = Exporter()
+    exporter.app = app
+    exporter.state = app.events.State()
+
+    sent_ts = time.time()
+    exporter.track_task_event(
+        _make_task_event("test-ql-123", "task-sent", sent_ts)
+    )
+    exporter.track_task_event(
+        _make_task_event("test-ql-123", "task-received", sent_ts + 5.0)
+    )
+
+    sample_value = exporter.registry.get_sample_value(
+        "celery_task_queue_latency_sum",
+        labels={"name": "dummy_task", "queue_name": "default"},
+    )
+    assert sample_value is not None
+    assert sample_value >= 4.9
+
+
+def test_queue_latency_negative_skipped():
+    """Test that negative queue latency (clock skew) is discarded."""
+    from celery import Celery
+
+    app = Celery(broker="memory://")
+    exporter = Exporter()
+    exporter.app = app
+    exporter.state = app.events.State()
+
+    sent_ts = time.time()
+    exporter.track_task_event(
+        _make_task_event("test-neg-latency", "task-sent", sent_ts)
+    )
+    # received_ts is before sent_ts (clock skew)
+    exporter.track_task_event(
+        _make_task_event("test-neg-latency", "task-received", sent_ts - 1.0)
+    )
+
+    sample_value = exporter.registry.get_sample_value(
+        "celery_task_queue_latency_sum",
+        labels={"name": "dummy_task", "queue_name": "default"},
+    )
+    assert sample_value is None or sample_value == 0.0
+
+
+def test_queue_latency_without_sent_event():
+    """Test that queue latency is gracefully skipped when task-sent was not emitted."""
+    from celery import Celery
+
+    app = Celery(broker="memory://")
+    exporter = Exporter()
+    exporter.app = app
+    exporter.state = app.events.State()
+
+    # Only send task-received without prior task-sent
+    exporter.track_task_event(
+        _make_task_event("test-no-sent", "task-received", time.time())
+    )
+
+    sample_value = exporter.registry.get_sample_value(
+        "celery_task_queue_latency_sum",
+        labels={"name": "dummy_task", "queue_name": "default"},
+    )
+    assert sample_value is None or sample_value == 0.0


### PR DESCRIPTION
## Summary

- Adds `celery_task_queue_latency` histogram that measures the time a task spends waiting in the queue between `task-sent` and `task-received` events
- Labels: `name`, `queue_name` (no `hostname` to limit cardinality — queue wait time is a property of the queue, not the worker)
- Gracefully skipped if `task.sent` is not available (i.e. `task_send_sent_event` is not enabled)
- Negative values (clock skew) are discarded
- Uses the same configurable buckets as `celery_task_runtime`

## Motivation

There is currently no metric for queue wait time. The existing `celery_task_runtime` only measures execution time after the worker picks up the task. Queue latency is essential for detecting backed-up queues and understanding end-to-end task latency.

## Requirements

- `task_send_sent_event = True` must be configured in Celery settings so that `task-sent` events are emitted

## Test plan

- [x] Unit test for positive queue latency observation
- [x] Unit test for negative latency (clock skew) being discarded
- [x] Unit test for graceful skip when `task-sent` was never emitted