### PR TITLE
Fix --purge-offline-worker-metrics

### DIFF
--- a/src/exporter.py
+++ b/src/exporter.py
@@ -322,9 +322,11 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
         event_name = "worker-online" if is_online else "worker-offline"
         hostname = get_hostname(event["hostname"])
         logger.debug("Received event='{}' for hostname='{}'", event_name, hostname)
-        self.celery_worker_up.labels(hostname=hostname, **self.static_label).set(value)
 
         if is_online:
+            self.celery_worker_up.labels(hostname=hostname, **self.static_label).set(
+                value
+            )
             self.worker_last_seen[hostname] = {
                 "ts": reverse_adjust_timestamp(
                     event["timestamp"], event.get("utcoffset")

--- a/src/test_metrics.py
+++ b/src/test_metrics.py
@@ -5,7 +5,7 @@ import pytest
 from celery.contrib.testing.worker import start_worker  # type: ignore
 from celery.utils.time import adjust_timestamp  # type: ignore
 
-from src.exporter import reverse_adjust_timestamp
+from src.exporter import Exporter, reverse_adjust_timestamp
 
 
 @pytest.fixture
@@ -193,6 +193,32 @@ def test_purge_offline_worker_metrics(
             labels={"hostname": hostname, "queue_name": "test", "name": "boosh"},
         )
         == expected_metric_value
+    )
+
+
+def test_worker_offline_event_does_not_recreate_purged_metric(hostname):
+    exporter = Exporter()
+    exporter.track_worker_status(
+        {"hostname": hostname, "timestamp": time.time(), "utcoffset": 0}, True
+    )
+    exporter.purge_worker_metrics(hostname)
+
+    assert (
+        exporter.registry.get_sample_value(
+            "celery_worker_up", labels={"hostname": hostname}
+        )
+        is None
+    )
+
+    exporter.track_worker_status(
+        {"hostname": hostname, "timestamp": time.time(), "utcoffset": 0}, False
+    )
+
+    assert (
+        exporter.registry.get_sample_value(
+            "celery_worker_up", labels={"hostname": hostname}
+        )
+        is None
     )
 
 


### PR DESCRIPTION
I believe this PR fixes the  `--purge-offline-worker-metrics` issue described at https://github.com/danihodovic/celery-exporter/issues/362 so a late `worker-offline` event does not recreate a purged worker metric.

The bug could happen in this sequence:

1. A worker is purged, removing its metrics from the exporter registry.
2. A later `worker-offline` event arrives for the same hostname.
3. `track_worker_status()` recreated `celery_worker_up{hostname="old-worker"} 0.0`.
4. Since the worker had already been removed from `worker_last_seen`, the recreated zero-valued series was no longer eligible for future purge.

Now only online events directly create/update `celery_worker_up`. Offline events go through `forget_worker()`, which already no-ops for unknown or already-purged workers.

Note: AI assistance was used during investigation and validation.