### PR TITLE
Add celery_task_queue_wait_time histogram

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ celery_task_retried_total | Sent if the task failed, but will be retried in the 
 celery_worker_up | Indicates if a worker has recently sent a heartbeat. | Gauge
 celery_worker_tasks_active | The number of tasks the worker is currently processing | Gauge
 celery_task_runtime_bucket | Histogram of runtime measurements for each task | Histogram
+celery_task_queue_wait_time_bucket | Histogram of the time tasks spend waiting in the queue before being executed, excluding deliberate ETA/countdown delay (retry backoff is delivered as an ETA and is excluded too). Requires [`task_send_sent_event`](https://docs.celeryq.dev/en/stable/userguide/configuration.html#task-send-sent-event) to be enabled. Buckets are configurable via `--buckets`. | Histogram
 celery_queue_length | The number of message in broker queue | Gauge
 celery_active_consumer_count | The number of active consumer in broker queue **(Only work for [RabbitMQ and Qpid](https://qpid.apache.org/) broker, more details at [here](https://github.com/danihodovic/celery-exporter/pull/118#issuecomment-1169870481))** | Gauge
 celery_active_worker_count | The number of active workers in broker queue | Gauge

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ celery_task_retried_total | Sent if the task failed, but will be retried in the 
 celery_worker_up | Indicates if a worker has recently sent a heartbeat. | Gauge
 celery_worker_tasks_active | The number of tasks the worker is currently processing | Gauge
 celery_task_runtime_bucket | Histogram of runtime measurements for each task | Histogram
-celery_task_queue_wait_time_bucket | Histogram of the time tasks spend waiting in the queue before being executed, excluding deliberate ETA/countdown delay (retry backoff is delivered as an ETA and is excluded too). Requires [`task_send_sent_event`](https://docs.celeryq.dev/en/stable/userguide/configuration.html#task-send-sent-event) to be enabled. Buckets are configurable via `--buckets`. | Histogram
+celery_task_queue_wait_time_bucket | Histogram of the time tasks spend waiting in the queue before being executed, excluding deliberate ETA/countdown delay (retry backoff is delivered as an ETA and is excluded too). Requires [`task_send_sent_event`](https://docs.celeryq.dev/en/stable/userguide/configuration.html#task-send-sent-event) to be enabled. Buckets are configurable via `--queue-wait-buckets`; the default spans 50ms-30min since queue waits blow past runtime-shaped buckets under backlog. | Histogram
 celery_queue_length | The number of message in broker queue | Gauge
 celery_active_consumer_count | The number of active consumer in broker queue **(Only work for [RabbitMQ and Qpid](https://qpid.apache.org/) broker, more details at [here](https://github.com/danihodovic/celery-exporter/pull/118#issuecomment-1169870481))** | Gauge
 celery_active_worker_count | The number of active workers in broker queue | Gauge

--- a/conftest.py
+++ b/conftest.py
@@ -3,6 +3,7 @@ import threading
 import copy
 
 import pytest
+from celery.events.state import State  # type: ignore
 
 from src.exporter import Exporter
 
@@ -160,3 +161,11 @@ def threaded_exporter_static_labels(exporter_instance_static_labels):
 @pytest.fixture()
 def hostname():
     return socket.gethostname()
+
+
+@pytest.fixture()
+def event_exporter():
+    """An exporter with task state tracking, fed events directly (no worker)."""
+    exporter = Exporter()
+    exporter.state = State()
+    return exporter

--- a/src/cli.py
+++ b/src/cli.py
@@ -4,7 +4,7 @@ import click
 import pretty_errors  # type: ignore
 from prometheus_client import Histogram
 
-from .exporter import Exporter
+from .exporter import DEFAULT_QUEUE_WAIT_BUCKETS, Exporter
 from .help import cmd_help
 
 # https://github.com/pallets/click/issues/448#issuecomment-246029304
@@ -12,6 +12,7 @@ from .help import cmd_help
 click.core._verify_python3_env = lambda: None  # type: ignore
 
 default_buckets_str = ",".join(map(str, Histogram.DEFAULT_BUCKETS))
+default_queue_wait_buckets_str = ",".join(map(str, DEFAULT_QUEUE_WAIT_BUCKETS))
 
 
 def _comma_seperated_argument(_ctx, _param, value):
@@ -83,6 +84,12 @@ def _eq_sign_separated_argument_to_dict(_ctx, _param, value):
     show_default=True,
     help="Buckets for runtime histogram",
 )
+@click.option(
+    "--queue-wait-buckets",
+    default=default_queue_wait_buckets_str,
+    show_default=True,
+    help="Buckets for queue wait time histogram",
+)
 @click.option("--log-level", default="INFO", show_default=True)
 @click.option(
     "--worker-timeout",
@@ -150,6 +157,7 @@ def cli(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too
     host,
     port,
     buckets,
+    queue_wait_buckets,
     log_level,
     broker_ssl_option,
     worker_timeout,
@@ -161,6 +169,7 @@ def cli(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too
     static_label,
 ):  # pylint: disable=unused-argument
     formatted_buckets = list(map(float, buckets.split(",")))
+    formatted_queue_wait_buckets = list(map(float, queue_wait_buckets.split(",")))
     ctx = click.get_current_context()
     Exporter(
         formatted_buckets,
@@ -171,4 +180,5 @@ def cli(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too
         metric_prefix,
         default_queue_name,
         static_label,
+        formatted_queue_wait_buckets,
     ).run(ctx.params)

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -9,7 +9,7 @@ from typing import Callable, Optional
 from celery import Celery
 from celery.events.state import State  # type: ignore
 from celery.utils import nodesplit  # type: ignore
-from celery.utils.time import utcoffset  # type: ignore
+from celery.utils.time import adjust_timestamp, maybe_iso8601, utcoffset  # type: ignore
 from kombu.exceptions import ChannelError  # type: ignore
 from loguru import logger
 from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram
@@ -118,6 +118,14 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
         self.celery_task_runtime = Histogram(
             f"{metric_prefix}task_runtime",
             "Histogram of task runtime measurements.",
+            ["name", "hostname", "queue_name", *self.static_label_keys],
+            registry=self.registry,
+            buckets=buckets or Histogram.DEFAULT_BUCKETS,
+        )
+        self.celery_task_queue_wait_time = Histogram(
+            f"{metric_prefix}task_queue_wait_time",
+            "Histogram of the time tasks spend waiting in the queue before "
+            "being executed, excluding deliberate ETA/countdown delay.",
             ["name", "hostname", "queue_name", *self.static_label_keys],
             registry=self.registry,
             buckets=buckets or Histogram.DEFAULT_BUCKETS,
@@ -306,6 +314,27 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
                 # task-sent is sent by various hosts (webservers, task creators)
                 # this causes label cardinality, therefore we do not want to instantiate the counter
                 counter.labels(**_labels).inc(0)
+
+        # observe queue wait time, excluding deliberate delay: countdown and
+        # retry backoff are delivered as an ETA
+        if event["type"] == "task-started" and task.sent is not None:
+            baseline = task.sent
+            eta = maybe_iso8601(task.eta)
+            if eta is not None:
+                # localise like the receiver localised the event timestamps
+                eta_timestamp = eta.timestamp()
+                if (event_utcoffset := event.get("utcoffset")) is not None:
+                    eta_timestamp = adjust_timestamp(eta_timestamp, event_utcoffset)
+                baseline = max(baseline, eta_timestamp)
+            # clock skew between producer and worker can push this negative
+            queue_wait_time = max(0.0, task.started - baseline)
+            self.celery_task_queue_wait_time.labels(**labels).observe(queue_wait_time)
+            logger.debug(
+                "Observed metric='{}' labels='{}': {}s",
+                self.celery_task_queue_wait_time._name,
+                labels,
+                queue_wait_time,
+            )
 
         # observe task runtime
         if event["type"] == "task-succeeded":

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -13,8 +13,30 @@ from celery.utils.time import adjust_timestamp, maybe_iso8601, utcoffset  # type
 from kombu.exceptions import ChannelError  # type: ignore
 from loguru import logger
 from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram
+from prometheus_client.utils import INF
 
 from .http_server import start_http_server
+
+# Queue wait time is a saturation signal: healthy queues sit near zero, but a
+# backlog can grow to minutes. Unlike the runtime default buckets there is no
+# sub-50ms resolution, spending the buckets on the 10s-30min range instead.
+DEFAULT_QUEUE_WAIT_BUCKETS = (
+    0.05,
+    0.1,
+    0.25,
+    0.5,
+    1,
+    2.5,
+    5,
+    10,
+    30,
+    60,
+    120,
+    300,
+    600,
+    1800,
+    INF,
+)
 
 
 class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branches
@@ -31,6 +53,7 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
         metric_prefix="celery_",
         default_queue_name="celery",
         static_label=None,
+        queue_wait_buckets=None,
     ):
         self.registry = CollectorRegistry(auto_describe=True)
         self.queue_cache = set(initial_queues or [])
@@ -128,7 +151,7 @@ class Exporter:  # pylint: disable=too-many-instance-attributes,too-many-branche
             "being executed, excluding deliberate ETA/countdown delay.",
             ["name", "hostname", "queue_name", *self.static_label_keys],
             registry=self.registry,
-            buckets=buckets or Histogram.DEFAULT_BUCKETS,
+            buckets=queue_wait_buckets or DEFAULT_QUEUE_WAIT_BUCKETS,
         )
         self.celery_queue_length = Gauge(
             f"{metric_prefix}queue_length",

--- a/src/help.py
+++ b/src/help.py
@@ -50,6 +50,7 @@ for metric in [
     temp_exporter.celery_worker_up,
     temp_exporter.worker_tasks_active,
     temp_exporter.celery_task_runtime,
+    temp_exporter.celery_task_queue_wait_time,
 ]:
     cmd_help += f"""
 \b

--- a/src/test_cli.py
+++ b/src/test_cli.py
@@ -6,6 +6,7 @@ from celery.contrib.testing.worker import start_worker  # type: ignore
 from requests.exceptions import HTTPError
 
 
+# pylint: disable=too-many-statements
 @pytest.mark.celery()
 def test_integration(broker, celery_app, threaded_exporter, hostname):
     exporter_url = f"http://localhost:{threaded_exporter.cfg['port']}/metrics"
@@ -106,6 +107,10 @@ def test_integration(broker, celery_app, threaded_exporter, hostname):
     )
     assert (
         f'celery_task_runtime_count{{hostname="{hostname}",name="src.test_cli.succeed",queue_name="celery"}} 2.0'
+        in res.text
+    )
+    assert (
+        f'celery_task_queue_wait_time_count{{hostname="{hostname}",name="src.test_cli.succeed",queue_name="celery"}} 2.0'
         in res.text
     )
     assert 'celery_queue_length{queue_name="celery"} 0.0' in res.text
@@ -267,6 +272,10 @@ def test_integration_static_labels(
     )
     assert (
         f'celery_task_runtime_count{{hostname="{hostname}",name="src.test_cli.succeed",queue_name="celery",{static_labels_str}}} 2.0'
+        in res.text
+    )
+    assert (
+        f'celery_task_queue_wait_time_count{{hostname="{hostname}",name="src.test_cli.succeed",queue_name="celery",{static_labels_str}}} 2.0'
         in res.text
     )
     assert (

--- a/src/test_metrics.py
+++ b/src/test_metrics.py
@@ -364,6 +364,18 @@ def test_queue_wait_time_not_observed_when_sent_event_missed(event_exporter):
     assert get_queue_wait_sample(event_exporter, "count") is None
 
 
+def test_queue_wait_time_buckets_independent_of_runtime_buckets():
+    exporter = Exporter(buckets=[1.0, 5.0], queue_wait_buckets=[2.0, 4.0])
+
+    # pylint: disable=protected-access
+    assert exporter.celery_task_queue_wait_time._upper_bounds == [
+        2.0,
+        4.0,
+        float("inf"),
+    ]
+    assert exporter.celery_task_runtime._upper_bounds == [1.0, 5.0, float("inf")]
+
+
 def test_queue_wait_time_excludes_eta_when_events_from_other_timezone(event_exporter):
     """The event receiver localises event timestamps based on the sender's
     utcoffset, while the ETA stays an absolute datetime. The ETA must be

--- a/src/test_metrics.py
+++ b/src/test_metrics.py
@@ -1,9 +1,10 @@
 import logging
 import time
+from datetime import datetime, timezone
 
 import pytest
 from celery.contrib.testing.worker import start_worker  # type: ignore
-from celery.utils.time import adjust_timestamp  # type: ignore
+from celery.utils.time import adjust_timestamp, utcoffset  # type: ignore
 
 from src.exporter import Exporter, reverse_adjust_timestamp
 
@@ -258,3 +259,136 @@ def test_worker_generic_task_sent_hostname(threaded_exporter, celery_app, hostna
             )
             is None
         )
+
+
+QUEUE_WAIT_TASK_NAME = "src.test_metrics.waiting_task"
+QUEUE_WAIT_BASE_TIME = 1_600_000_000.0
+
+
+def make_task_event(event_type, timestamp, utcoffset=None):
+    return {
+        "type": event_type,
+        "uuid": "7d9b0b6c-6b1e-4c1e-a0f5-000000000001",
+        "timestamp": timestamp,
+        "local_received": timestamp,
+        "hostname": "worker@wait-test-host",
+        "clock": 1,
+        "utcoffset": utcoffset,
+    }
+
+
+def make_task_sent_event(timestamp, eta=None, retries=0, utcoffset=None):
+    event = make_task_event("task-sent", timestamp, utcoffset=utcoffset)
+    event.update(name=QUEUE_WAIT_TASK_NAME, queue="celery", eta=eta, retries=retries)
+    return event
+
+
+def isoformat_eta(timestamp):
+    return datetime.fromtimestamp(timestamp, tz=timezone.utc).isoformat()
+
+
+def get_queue_wait_sample(exporter, suffix):
+    return exporter.registry.get_sample_value(
+        f"celery_task_queue_wait_time_{suffix}",
+        labels={
+            "name": QUEUE_WAIT_TASK_NAME,
+            "hostname": "wait-test-host",
+            "queue_name": "celery",
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    "eta,started_offset,expected_wait",
+    [
+        pytest.param(None, 5, 5.0, id="plain-task"),
+        pytest.param(
+            isoformat_eta(QUEUE_WAIT_BASE_TIME + 120),
+            123,
+            3.0,
+            id="future-eta-excluded",
+        ),
+        pytest.param(
+            isoformat_eta(QUEUE_WAIT_BASE_TIME - 60),
+            5,
+            5.0,
+            id="past-eta-ignored",
+        ),
+        pytest.param(None, -2, 0.0, id="clamped-to-zero-on-clock-skew"),
+    ],
+)
+def test_queue_wait_time(event_exporter, eta, started_offset, expected_wait):
+    """A task is sent at the base time (optionally with an ETA) and started
+    `started_offset` seconds later; the wait is measured from max(sent, eta)
+    and clamped at zero."""
+    event_exporter.track_task_event(make_task_sent_event(QUEUE_WAIT_BASE_TIME, eta=eta))
+    event_exporter.track_task_event(
+        make_task_event("task-started", QUEUE_WAIT_BASE_TIME + started_offset)
+    )
+
+    assert get_queue_wait_sample(event_exporter, "count") == 1.0
+    assert get_queue_wait_sample(event_exporter, "sum") == pytest.approx(expected_wait)
+
+
+def test_queue_wait_time_measures_each_retry_delivery_without_backoff(event_exporter):
+    # first delivery: waits 1s
+    event_exporter.track_task_event(make_task_sent_event(QUEUE_WAIT_BASE_TIME))
+    event_exporter.track_task_event(
+        make_task_event("task-started", QUEUE_WAIT_BASE_TIME + 1)
+    )
+    event_exporter.track_task_event(
+        make_task_event("task-retried", QUEUE_WAIT_BASE_TIME + 2)
+    )
+    # retry delivery: republished with a 30s backoff ETA, waits 3s past it
+    event_exporter.track_task_event(
+        make_task_sent_event(
+            QUEUE_WAIT_BASE_TIME + 2,
+            eta=isoformat_eta(QUEUE_WAIT_BASE_TIME + 32),
+            retries=1,
+        )
+    )
+    event_exporter.track_task_event(
+        make_task_event("task-started", QUEUE_WAIT_BASE_TIME + 35)
+    )
+
+    # 1s for the first delivery plus 3s for the retry delivery
+    assert get_queue_wait_sample(event_exporter, "count") == 2.0
+    assert get_queue_wait_sample(event_exporter, "sum") == pytest.approx(4.0)
+
+
+def test_queue_wait_time_not_observed_when_sent_event_missed(event_exporter):
+    event_exporter.track_task_event(
+        make_task_event("task-started", QUEUE_WAIT_BASE_TIME)
+    )
+
+    assert get_queue_wait_sample(event_exporter, "count") is None
+
+
+def test_queue_wait_time_excludes_eta_when_events_from_other_timezone(event_exporter):
+    """The event receiver localises event timestamps based on the sender's
+    utcoffset, while the ETA stays an absolute datetime. The ETA must be
+    localised the same way, or the exclusion silently never applies when the
+    producer/worker timezone differs from the exporter's."""
+    source_utcoffset = utcoffset() + 4
+
+    def localise(timestamp):
+        # what Receiver.event_from_message does to event timestamps
+        return adjust_timestamp(timestamp, source_utcoffset)
+
+    event_exporter.track_task_event(
+        make_task_sent_event(
+            localise(QUEUE_WAIT_BASE_TIME),
+            eta=isoformat_eta(QUEUE_WAIT_BASE_TIME + 120),
+            utcoffset=source_utcoffset,
+        )
+    )
+    event_exporter.track_task_event(
+        make_task_event(
+            "task-started",
+            localise(QUEUE_WAIT_BASE_TIME + 123),
+            utcoffset=source_utcoffset,
+        )
+    )
+
+    assert get_queue_wait_sample(event_exporter, "count") == 1.0
+    assert get_queue_wait_sample(event_exporter, "sum") == pytest.approx(3.0)


### PR DESCRIPTION
Closes #316.

Adds `celery_task_queue_wait_time`, a histogram of how long tasks wait between being published and starting execution, excluding deliberate ETA/countdown delay (retry backoff is delivered as an ETA and is excluded too). Requires [`task_send_sent_event`](https://docs.celeryq.dev/en/stable/userguide/configuration.html#task-send-sent-event) to be enabled.

Labelled by `name`, `hostname`, and `queue_name` (plus any static labels), matching `celery_task_runtime` for consistency with the rest of the `celery_task_*` metrics.

## Buckets

Queue wait time gets its own `--queue-wait-buckets` flag rather than reusing `--buckets`, because the two histograms measure different distributions:

- `celery_task_runtime` is bounded by what the task itself does, and the `prometheus_client` defaults (5ms-10s) suit it fine.
- Queue wait is a saturation signal: healthy queues sit near zero, but under backlog it grows to minutes. With runtime-shaped buckets, any wait past 10s collapses into `+Inf`, so `histogram_quantile` clips at 10s and a 15s blip becomes indistinguishable from a 30-minute outage — exactly the case this metric exists to catch.

Default is `0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600, 1800` (+Inf implicit): 14 finite buckets, one fewer than `Histogram.DEFAULT_BUCKETS`. Rather than finely measuring waits under 50ms (useful for runtime, meaningless here — an 8ms wait and a 20ms wait both just mean "healthy"), this histogram spends its buckets on the 30-second-to-30-minute range instead, since that's where a growing backlog actually shows up.

| Zone | Bounds | What it means |
|---|---|---|
| Healthy | 0.05 – 1 (5 buckets) | Normal operation: p50/p95 sit here; median wait creep is an early capacity signal |
| Degrading | 2.5 – 10 (3 buckets) | The transition: workers no longer keeping up, but not yet an incident |
| Backlog | 30 – 1800 (6 buckets) | Queue growth: distinguishes a 45s blip from a 5-minute wobble from a 25-minute outage |

This default is a judgment call rather than a hard requirement — happy to adjust it (or default to `Histogram.DEFAULT_BUCKETS` for consistency with `--buckets`) if you'd prefer something else.

## Testing

Parametrized unit tests cover: plain wait, future ETA (excluded), past ETA (ignored), retry backoff (measured per delivery, backoff excluded), clock skew (clamped to zero), missing `task-sent` event (not observed), cross-timezone ETA localisation, and independence of the two bucket sets. End-to-end coverage in `test_cli.py`.
